### PR TITLE
Adapt to UniMath’s refactoring of precategories

### DIFF
--- a/TypeTheory/ALV2/CwF_SplitTypeCat_Equiv_Cats.v
+++ b/TypeTheory/ALV2/CwF_SplitTypeCat_Equiv_Cats.v
@@ -289,7 +289,7 @@ Proof.
     etrans. 2: { cbn. apply maponpaths_2, @pathsinv0, obj_ext_mor_ax. }
     exact (toforallpaths _ _ _ (nat_trans_ax (obj_ext_mor_TY F) _ _ _) _).
   - etrans. 2: { apply @pathsinv0, 
-        (postCompWithPullbackArrow _ _ _ (make_Pullback _ _ _ _ _ _ _)). }
+        (postCompWithPullbackArrow _ _ _ _ (make_Pullback _ _)). }
     apply PullbackArrowUnique.
     + cbn.
       etrans. apply @pathsinv0, assoc.
@@ -302,7 +302,7 @@ Proof.
       etrans. apply maponpaths, comp_ext_compare_π.
       etrans. apply @pathsinv0, assoc.
       etrans. apply maponpaths, obj_ext_mor_ax.
-      apply (PullbackArrow_PullbackPr1 (make_Pullback _ _ _ _ _ _ _)).
+      apply (PullbackArrow_PullbackPr1 (make_Pullback _ _)).
     + etrans. 2: { apply @pathsinv0, id_right. }
       etrans. cbn. apply maponpaths_2, maponpaths_2, maponpaths.
         etrans. apply comp_ext_compare_comp.
@@ -322,7 +322,7 @@ Proof.
         (* TODO: give access function [qq_structure_mor_ax]! *)
       etrans. apply assoc.
       etrans. apply maponpaths_2.
-        apply (PullbackArrow_PullbackPr2 (make_Pullback _ _ _ _ _ _ _)).
+        apply (PullbackArrow_PullbackPr2 (make_Pullback _ _)).
       apply id_left.
 Time Qed.
 

--- a/TypeTheory/ALV2/CwF_SplitTypeCat_Univalent_Cats.v
+++ b/TypeTheory/ALV2/CwF_SplitTypeCat_Univalent_Cats.v
@@ -56,7 +56,7 @@ Section Is_Univalent_Obj_Ext_Disp.
   *)
 
   Lemma slice_maps_to_obj_ext_map {TY : PreShv C} {X X' : obj_ext_disp TY}
-    : (∏ Γ A, slice_precat C Γ (homset_property C) ⟦ X Γ A , X' Γ A ⟧)
+    : (∏ Γ A, slice_precat C Γ ⟦ X Γ A , X' Γ A ⟧)
     -> X -->[identity_iso TY] X'.
   Proof.
     intros I Γ A.
@@ -65,7 +65,7 @@ Section Is_Univalent_Obj_Ext_Disp.
   Defined.
 
   Lemma is_iso_slice_isos_to_obj_ext_map {TY : PreShv C} {X X' : obj_ext_disp TY}
-    (I : ∏ Γ A, @iso (slice_precat C Γ (homset_property C)) (X Γ A) (X' Γ A))
+    (I : ∏ Γ A, @iso (slice_precat C Γ) (X Γ A) (X' Γ A))
     : is_iso_disp (identity_iso _) (slice_maps_to_obj_ext_map (fun Γ A => I Γ A)).
   Proof.
     exists (slice_maps_to_obj_ext_map (fun Γ A => inv_from_iso (I Γ A))).
@@ -83,7 +83,7 @@ Section Is_Univalent_Obj_Ext_Disp.
   Qed.
 
   Lemma slice_isos_to_obj_ext_iso {TY : PreShv C} (X X' : obj_ext_disp TY)
-    : (∏ Γ A, @iso (slice_precat C Γ (homset_property C)) (X Γ A) (X' Γ A))
+    : (∏ Γ A, @iso (slice_precat C Γ) (X Γ A) (X' Γ A))
     -> iso_disp (identity_iso TY) X X'.
   Proof.
     intros I.
@@ -93,7 +93,7 @@ Section Is_Univalent_Obj_Ext_Disp.
 
   Lemma obj_ext_map_to_slice_maps {TY : PreShv C} {X X' : obj_ext_disp TY}
     : X -->[identity_iso TY] X'
-      -> (∏ Γ A, slice_precat C Γ (homset_property C) ⟦ X Γ A , X' Γ A ⟧).
+      -> (∏ Γ A, slice_precat C Γ ⟦ X Γ A , X' Γ A ⟧).
   Proof.
     intros I Γ A.
     exists (pr1 (I Γ A)).  
@@ -142,7 +142,7 @@ Section Is_Univalent_Obj_Ext_Disp.
   Qed.
 
   Lemma weq_slice_isos_obj_ext_iso {TY : PreShv C} (X X' : obj_ext_disp TY)
-    : (∏ Γ A, @iso (slice_precat C Γ (homset_property C)) (X Γ A) (X' Γ A))
+    : (∏ Γ A, @iso (slice_precat C Γ) (X Γ A) (X' Γ A))
     ≃ iso_disp (identity_iso TY) X X'.
   Proof.
     exists (slice_isos_to_obj_ext_iso _ _).
@@ -185,7 +185,7 @@ Section Is_Univalent_Obj_Ext_Disp.
   Theorem is_univalent_obj_ext : is_univalent (obj_ext_cat C).
   Proof.
     apply is_univalent_total_category.
-    - apply is_univalent_functor_category.
+    - apply is_univalent_functor_category, univalent_category_is_univalent.
     - apply is_univalent_obj_ext_disp.
   Defined.
 

--- a/TypeTheory/Auxiliary/CategoryTheoryImports.v
+++ b/TypeTheory/Auxiliary/CategoryTheoryImports.v
@@ -22,7 +22,6 @@ Require Export UniMath.CategoryTheory.Presheaf.
 Declare Scope precat.
 Notation "C '^op'" := (opp_precat C) (at level 3, format "C ^op") : precat.
 Delimit Scope precat with precat.
-Bind Scope precat with precategory.
 
 Open Scope cat.
 Open Scope cat_deprecated.

--- a/TypeTheory/Auxiliary/CategoryTheoryImports.v
+++ b/TypeTheory/Auxiliary/CategoryTheoryImports.v
@@ -19,5 +19,10 @@ Require Export UniMath.CategoryTheory.yoneda.
 Require Export UniMath.CategoryTheory.categories.HSET.Core.
 Require Export UniMath.CategoryTheory.Presheaf.
 
+Declare Scope precat.
+Notation "C '^op'" := (opp_precat C) (at level 3, format "C ^op") : precat.
+Delimit Scope precat with precat.
+Bind Scope precat with precategory.
+
 Open Scope cat.
 Open Scope cat_deprecated.

--- a/TypeTheory/Categories/category_of_elements.v
+++ b/TypeTheory/Categories/category_of_elements.v
@@ -3,7 +3,7 @@
 (**
   Contents:
 
-    - not much yet
+    - category of elements of a covariant functor, including its univalence
 *)
 
 Require Import UniMath.Foundations.Sets.
@@ -13,11 +13,10 @@ Require Import UniMath.CategoryTheory.opp_precat.
 Require Import TypeTheory.Auxiliary.Auxiliary.
 Require Import TypeTheory.Auxiliary.CategoryTheoryImports.
 
+(* TODO: refactor as displayed category? *)
+Section precategory_of_elements_covariant.
 
-Section category_of_elements_covariant.
-
-Variable C : precategory.
-Variable F : functor C HSET.
+Context {C : precategory} (F : functor C HSET).
 
 Definition precategory_of_elements_ob_mor : precategory_ob_mor.
 Proof.
@@ -60,6 +59,14 @@ Qed.
 Definition precategory_of_elements : precategory 
   := (_,,is_precategory_precategory_of_elements).
 
+Lemma precategory_of_elements_has_homsets
+  : has_homsets C -> has_homsets precategory_of_elements.
+Proof.
+  intros H ca db. apply isaset_total2.
+  - apply H.
+  - intros; apply isasetaprop, setproperty.
+Defined.
+
 Local Notation "∫" := precategory_of_elements.
 (* written \int in agda input mode *)
 
@@ -79,6 +86,18 @@ Qed.
 
 Definition proj_functor : functor _ _ := tpair _ _ is_functor_proj.
 
+End precategory_of_elements_covariant.
+
+Section category_of_elements.
+
+Context {C : category} (F : functor C HSET).
+
+Definition category_of_elements
+  := make_category _
+       (precategory_of_elements_has_homsets F (homset_property C)).
+
+Local Notation "∫" := category_of_elements.
+(* written \int in agda input mode *)
 
 Definition Elem_cov_iso_type (ac bd : ∫) : UU
   := ∑ (f : iso (pr1 ac) (pr1 bd)), #F f (pr2 ac) = pr2 bd.
@@ -188,7 +207,7 @@ Proof.
   eapply weqcomp.
   apply total2_paths_equiv.
   unshelve refine (weqbandf (make_weq (@idtoiso _ _ _ ) _ ) _ _ _ ).
-  - apply (pr1 H).
+  - apply H.
   - simpl. intro x.
     destruct ac. destruct bd.
     simpl in *.
@@ -211,28 +230,22 @@ Defined.
 
 Definition is_univalent_Elem  (H : is_univalent C) : is_univalent ∫.
 Proof.
-  split.
-  - intros a b.
-    set (T := isweqhomot (foobar  H a b)(@idtoiso _ a b) ).
-    apply T.
-    intro p.
-    induction p.
-    destruct a; simpl in *.
-    
-    simpl.
-    apply eq_iso.
-    simpl.
-    apply subtypePath. intro; apply setproperty.
-    apply idpath.
-    apply pr2.
-  - intros a b.
-    apply (isofhleveltotal2 2).
-    apply (pr2 H).
-    intro. apply isasetaprop.
-    apply setproperty.
+  intros a b.
+  set (T := isweqhomot (foobar  H a b)(@idtoiso _ a b) ).
+  apply T.
+  intro p.
+  induction p.
+  destruct a; simpl in *.
+  
+  simpl.
+  apply eq_iso.
+  simpl.
+  apply subtypePath. intro; apply setproperty.
+  apply idpath.
+  apply pr2.
 Defined.
 
-End category_of_elements_covariant.
+End category_of_elements.
 
 
 (*

--- a/TypeTheory/Csystems/lCsystems.v
+++ b/TypeTheory/Csystems/lCsystems.v
@@ -580,9 +580,7 @@ Qed.
 
 Definition q_of_f_is_pullback_type {CC: lC0system}{X Y: CC}
   (gt0: ll X > 0)(f: Y --> ft X): UU :=
-  isPullback (C0eiso gt0 f · f) (pnX 1 X)
-             (pnX 1 (f_star gt0 f)) (q_of_f gt0 f)
-             (C0ax5c gt0 f).
+  isPullback (C0ax5c gt0 f).
 
 Lemma q_of_f_is_pullback {CC: lCsystem}{X Y: CC} (gt0: ll X > 0)(f: Y --> ft X):
   q_of_f_is_pullback_type gt0 f.

--- a/TypeTheory/Cubical/FillFromComp.v
+++ b/TypeTheory/Cubical/FillFromComp.v
@@ -110,12 +110,12 @@ Arguments isPullback {_ _ _ _ _ _ _ _ _} _.
 
 Section cubical.
 
-Context {C : precategory} (hsC : has_homsets C) (BPC : BinProducts C).
+Context {C : category} (BPC : BinProducts C).
 
 (* Setup notations *)
 Local Notation "Γ ⊢" := (PreShv (∫ Γ)) (at level 50).
 Local Notation "Γ ⊢ A" := (@TermIn _ Γ A) (at level 50).
-Local Notation "A ⦃ s ⦄" := (subst_type hsC A s) (at level 40, format "A ⦃ s ⦄").
+Local Notation "A ⦃ s ⦄" := (subst_type A s) (at level 40, format "A ⦃ s ⦄").
 Local Notation "Γ ⋆ A" := (@ctx_ext _ Γ A) (at level 30).
 Local Notation "c '⊗' d" :=
   (BinProductObject _ (@BinProducts_PreShv C c d)) : cat.
@@ -292,14 +292,14 @@ Lemma isPullback_pF_e₀ I J (f : J --> I) :
   isPullback (nat_trans_ax p_F f) → isPullback (nat_trans_ax e₀ f).
 Proof.
 intros H.
-apply (isPullback_two_pullback hsC _ _ _ _ _ _ H).
+apply (isPullback_two_pullback (homset_property _) _ _ _ _ _ _ H).
 intros K g h Hgh.
 use (unique_exists h); simpl in *.
 - rewrite <- Hgh.
   set (HI := nat_trans_eq_pointwise Hpe₀ I).
   set (HJ := nat_trans_eq_pointwise Hpe₀ J); cbn in HI, HJ.
   now rewrite HI, HJ, !id_right.
-- now intros HH; apply isapropdirprod; apply hsC.
+- now intros HH; apply isapropdirprod; apply homset_property.
 - intros h' [H1 H2].
   rewrite <- H2.
   set (HH := nat_trans_eq_pointwise Hpe₀ J); cbn in HH.
@@ -359,7 +359,7 @@ now rewrite <-!assoc, H2, H3, assoc, H4, id_left, id_right.
 Qed.
 
 (* We can lift the above operations to presheaves using yoneda *)
-Let yon := yoneda_functor_data C hsC.
+Let yon := yoneda_functor_data C.
 
 Definition p_PreShv (I : C) : yon (I+) --> yon I := # yon (p_F I).
 
@@ -391,7 +391,7 @@ use make_nat_trans.
   now apply funextsec; intro x; cbn; rewrite assoc.
 Defined.
 
-Lemma isMonic_e₀_PreShv I : isMonic (e₀_PreShv I).
+Lemma isMonic_e₀_PreShv I : @isMonic (PreShv C) _ _ (e₀_PreShv I).
 Proof.
 intros Γ σ τ H.
 apply (nat_trans_eq has_homsets_HSET); intros J; apply funextsec; intro ρ.
@@ -399,7 +399,7 @@ generalize (eqtohomot (nat_trans_eq_pointwise H J) ρ).
 now apply isMonic_e₀.
 Qed.
 
-Lemma isMonic_e₁_PreShv I : isMonic (e₁_PreShv I).
+Lemma isMonic_e₁_PreShv I : @isMonic (PreShv C) _ _ (e₁_PreShv I).
 Proof.
 intros Γ σ τ H.
 apply (nat_trans_eq has_homsets_HSET); intros J; apply funextsec; intro ρ.

--- a/TypeTheory/Initiality/SplitTypeCat_Contextual.v
+++ b/TypeTheory/Initiality/SplitTypeCat_Contextual.v
@@ -12,13 +12,13 @@ Require Import TypeTheory.Initiality.SplitTypeCat_General.
 (* These two lemmas should be upstreamed to UniMath/CategoryTheory/limits/terminal.v and initial.v *)
 Section upstream.
 
-  Lemma isaprop_isTerminal {C : precategory} (x : C) : isaprop (isTerminal C x).
+  Lemma isaprop_isTerminal {C : category} (x : C) : isaprop (isTerminal C x).
   Proof.
     repeat (apply impred; intro).
     apply isapropiscontr.
   Qed.
 
-  Lemma isaprop_isInitial {C : precategory} (x : C) : isaprop (isInitial C x).
+  Lemma isaprop_isInitial {C : category} (x : C) : isaprop (isInitial C x).
   Proof.
     repeat (apply impred; intro).
     apply isapropiscontr.

--- a/TypeTheory/Initiality/SplitTypeCat_General.v
+++ b/TypeTheory/Initiality/SplitTypeCat_General.v
@@ -11,7 +11,7 @@ Require Import TypeTheory.Auxiliary.CategoryTheoryImports.
 Require Import TypeTheory.Auxiliary.Auxiliary.
 Require Import TypeTheory.ALV1.TypeCat.
 
-(* This should be upstreamed *)
+(* TODO: upstream? *)
 Arguments nat_trans_ax {C C'} {F F'} a {x x'} f.
 
 Local Open Scope cat.
@@ -161,7 +161,7 @@ Section Terms.
     : reind_tm f a ;; q_typecat A f = f ;; a.
   Proof.
     simpl.
-    set (pb := make_Pullback _ _ _ _ _ _ _).
+    set (pb := make_Pullback _ _).
     now rewrite (PullbackArrow_PullbackPr2 pb).
   Qed.
 
@@ -230,9 +230,9 @@ Section Terms.
       = tm_transportb (reind_id_type_typecat _ _) a.
   Proof.
     apply subtypePath; [ intros x; apply homset_property|]; simpl.
-    set (pb := make_Pullback _ _ _ _ _ _ _).
+    set (pb := make_Pullback _ _).
     (* Why is there a ' version of this lemma??? *)
-    apply pathsinv0, (PullbackArrowUnique' _ _ pb).
+    apply pathsinv0, (PullbackArrowUnique' _ _ _ pb).
     - rewrite <-assoc.
       etrans; [eapply maponpaths, idtoiso_dpr_typecat|].
       exact (pr2 a).
@@ -257,10 +257,10 @@ Section Terms.
           (reind_tm g (reind_tm f a)).
   Proof.
     apply subtypePath; [ intros x; apply homset_property|]; simpl.
-    set (pb := make_Pullback _ _ _ _ _ _ _).
-    set (pb' := make_Pullback _ _ _ _ _ _ _).
-    set (pb'' := make_Pullback _ _ _ _ _ _ _).
-    apply pathsinv0, (PullbackArrowUnique' _ _ pb).
+    set (pb := make_Pullback _ _).
+    set (pb' := make_Pullback _ _).
+    set (pb'' := make_Pullback _ _).
+    apply pathsinv0, (PullbackArrowUnique' _ _ _ pb).
     - rewrite <- assoc.
       etrans; [eapply maponpaths, idtoiso_dpr_typecat|].
       apply (PullbackArrow_PullbackPr1 pb').
@@ -329,8 +329,8 @@ Section Terms.
     apply pathsinv0, PullbackArrowUnique.
     { apply (section_property (tm_transportb _ _)). }
     apply pathsinv0.
-    etrans. { refine (postCompWithPullbackArrow _ _ _
-                                       (make_Pullback _ _ _ _ _ _ _) _ _ _). }
+    etrans. { refine (postCompWithPullbackArrow _ _ _ _
+                                       (make_Pullback _ _) _ _ _). }
     apply pathsinv0, PullbackArrowUnique; cbn; refine (_ @ ! id_right _).
     - rewrite <- assoc.
       etrans. { apply maponpaths, dpr_q_typecat. }
@@ -378,7 +378,7 @@ Section Terms.
     + now induction e; rewrite <-assoc, id_left.
     + unfold map_into_Pb.
       set (pb := Auxiliary.Pbb _ _ _ _ _ _ _ _ _ _ _).
-      rewrite <-assoc, (postCompWithPullbackArrow _ _ _ pb).
+      rewrite <-assoc, (postCompWithPullbackArrow _ _ _ _ pb).
       apply PullbackArrowUnique; cbn.
     - rewrite <-!assoc, dpr_q_typecat; induction e.
       now rewrite id_left, assoc, af, id_left, id_right.

--- a/TypeTheory/Initiality/SplitTypeCat_Maps.v
+++ b/TypeTheory/Initiality/SplitTypeCat_Maps.v
@@ -262,7 +262,7 @@ Section Derived_Actions.
     reind_tm (# F f) (fmap_tm F a).
   Proof.
     apply paths_tm, PullbackArrowUnique; cbn; simpl;
-      set (pb := make_Pullback _ _ _ _ _ _ _); rewrite <-!assoc.
+      set (pb := make_Pullback _ _); rewrite <-!assoc.
     - etrans; [apply maponpaths, maponpaths, comp_ext_compare_dpr_typecat|].
       etrans; [apply maponpaths, (!typecat_mor_triangle F (A ⦃f⦄))|].
       now rewrite <- functor_comp, (PullbackArrow_PullbackPr1 pb), functor_id.
@@ -328,8 +328,7 @@ Section Derived_Actions.
         etrans. { apply assoc. }
         etrans. { apply maponpaths_2, assoc. }
         etrans. { apply maponpaths_2, maponpaths_2.
-                  refine (PullbackArrow_PullbackPr2
-                            (make_Pullback _ _ _ _ _ _ _) _ _ _ _). }
+          refine (PullbackArrow_PullbackPr2 (make_Pullback _ _) _ _ _ _). }
         simpl pr1.
         etrans. { apply maponpaths_2, maponpaths_2, assoc. }
         etrans. { apply pathsinv0, assoc. }
@@ -343,8 +342,7 @@ Section Derived_Actions.
           etrans. { apply pathsinv0, functor_comp. }
           etrans.
           { apply maponpaths.
-            refine (PullbackArrow_PullbackPr2
-                            (make_Pullback _ _ _ _ _ _ _) _ _ _ _).
+            refine (PullbackArrow_PullbackPr2 (make_Pullback _ _) _ _ _ _).
           }
           apply functor_id.
         }

--- a/TypeTheory/Instances/Presheaves.v
+++ b/TypeTheory/Instances/Presheaves.v
@@ -125,7 +125,7 @@ Local Open Scope cat.
 
 Section presheaves.
 
-Context {C : precategory} (hsC : has_homsets C).
+Context {C : category}.
 
 (** Γ ⊢ A is interpreted as a presheaf of ∫ Γ. In Coq this is written A : Γ ⊢ *)
 Local Notation "Γ ⊢" := (PreShv (∫ Γ)) (at level 50).
@@ -136,16 +136,15 @@ Local Notation "'1'" := (nat_trans_id _).
 Definition subst_functor {Γ Δ : PreShv C} (σ : Δ --> Γ) :
   functor (PreShv (∫ Γ)) (PreShv (∫ Δ)).
 Proof.
-use pre_composition_functor.
-- apply has_homsets_opp, has_homsets_cat_of_elems, hsC.
-- apply functor_opp, (cat_of_elems_on_nat_trans σ).
+  use pre_composition_functor.
+  apply functor_opp, (cat_of_elems_on_nat_trans σ).
 Defined.
 
 (** WARNING: Only use this for small C *)
 Lemma is_left_adjoint_subst_functor {Γ Δ : PreShv C} (σ : Δ --> Γ) :
   is_left_adjoint (subst_functor σ).
 Proof.
-use (RightKanExtension_from_limits _ _ _ LimsHSET). (* apply is slow here... *)
+  apply RightKanExtension_from_limits, LimsHSET.
 Defined.
 
 (** The right adjoint to substitution *)
@@ -583,11 +582,11 @@ End presheaves.
 (** * Presheaf categories are type categories *)
 Section TypeCat.
 
-Context (C : precategory) (hsC : has_homsets C).
+Context (C : category).
 
 Local Notation "Γ ⊢" := (PreShv (∫ Γ)) (at level 50).
 Local Notation "Γ ⊢ A" := (@TermIn _ Γ A) (at level 50).
-Local Notation "A ⦃ s ⦄" := (subst_type hsC A s) (at level 40, format "A ⦃ s ⦄").
+Local Notation "A ⦃ s ⦄" := (subst_type A s) (at level 40, format "A ⦃ s ⦄").
 Local Notation "Γ ⋆ A" := (@ctx_ext _ Γ A) (at level 30).
 
 Definition PreShv_TypeCat : typecat_structure (PreShv C).
@@ -598,12 +597,12 @@ use tpair.
   intros Γ A Δ σ.
   exact (A⦃σ⦄).
 - exists (λ Γ A, @ctx_proj _ Γ A).
-  exists (λ Γ A Δ σ, q_gen_mor hsC A σ).
-  exists (λ Γ A Δ σ, q_gen_mor_p hsC A σ).
+  exists (λ Γ A Δ σ, q_gen_mor A σ).
+  exists (λ Γ A Δ σ, q_gen_mor_p A σ).
   intros Γ A Δ σ.
   apply is_symmetric_isPullback.
   + apply (functor_category_has_homsets C^op).
-  + exact (isPullback_q_gen_mor hsC A σ).
+  + exact (isPullback_q_gen_mor A σ).
 Defined.
 
 End TypeCat.
@@ -613,11 +612,11 @@ Section CwF.
 
 Require Import TypeTheory.OtherDefs.CwF_Pitts.
 
-Context (C : precategory) (hsC : has_homsets C).
+Context (C : category).
 
 Local Notation "Γ ⊢" := (PreShv (∫ Γ)) (at level 50).
 Local Notation "Γ ⊢ A" := (@TermIn _ Γ A) (at level 50).
-Local Notation "A ⦃ s ⦄" := (subst_type hsC A s) (at level 40, format "A ⦃ s ⦄").
+Local Notation "A ⦃ s ⦄" := (subst_type A s) (at level 40, format "A ⦃ s ⦄").
 Local Notation "Γ ⋆ A" := (@ctx_ext _ Γ A) (at level 30).
 
 Definition PreShv_tt_structure : tt_structure (PreShv C).
@@ -633,7 +632,7 @@ use tpair.
 - intros Γ Δ A σ.
   exact (A⦃σ⦄).
 - intros Γ Δ A a σ.
-  exact (subst_term _ σ a).
+  exact (subst_term σ a).
 Defined.
 
 Definition PreShv_tt_reindx_type_struct : tt_reindx_type_struct (PreShv C).
@@ -647,7 +646,7 @@ use tpair.
   split.
   * apply ctx_last.
   * intros Δ σ a.
-    exact (subst_pair hsC σ a).
+    exact (subst_pair σ a).
 Defined.
 
 Lemma PreShv_reindx_laws : reindx_laws PreShv_tt_reindx_type_struct.
@@ -657,12 +656,12 @@ use tpair.
   + intros Γ A.
     apply subst_type_id.
   + intros Γ Δ Θ σ1 σ2 A.
-    apply (subst_type_comp hsC).
+    apply subst_type_comp.
 - use tpair.
   + intros Γ A a.
-    apply (subst_term_id hsC a).
+    apply (subst_term_id a).
   + intros Γ Δ Θ σ1 σ2 A a.
-    exact (subst_term_comp hsC σ2 σ1 a).
+    exact (subst_term_comp σ2 σ1 a).
 Defined.
 
 (* This is commented as we cannot complete it *)

--- a/TypeTheory/Instances/VSets.v
+++ b/TypeTheory/Instances/VSets.v
@@ -238,7 +238,7 @@ exists VSET_tt_reindx_type_struct. use tpair.
   + split; [apply VSET_reindx_comp_law_3 | apply VSET_reindx_comp_law_4].
 - split.
   + intros Γ Δ. apply isaset_set_fun_space.
-  + split; intros; apply isaset_forall_hSet.
+  + intros; apply isaset_forall_hSet.
 Defined.
 
 End VSET_CwF.

--- a/TypeTheory/OtherDefs/CwF_1.v
+++ b/TypeTheory/OtherDefs/CwF_1.v
@@ -20,7 +20,7 @@ Require Import UniMath.CategoryTheory.limits.pullbacks.
 Require Import TypeTheory.Auxiliary.CategoryTheoryImports.
 Require Import TypeTheory.Auxiliary.Auxiliary.
 
-
+Local Open Scope precat.
 Local Notation "# F" := (functor_on_morphisms F)(at level 3).
 
 (** * A "preview" of the definition *)
@@ -702,7 +702,7 @@ Qed.
 
 Lemma is_pullback_reindx_cwf (hs : has_homsets CC) : ∏ (Γ : CC) (A : C⟨Γ⟩) (Γ' : CC) 
    (f : Γ' --> Γ),
-   isPullback (π A) f (q_precwf A f) (π (A [[f]])) (dpr_q_precwf A f).
+   isPullback (dpr_q_precwf A f).
 Proof.
   intros.
   apply make_isPullback; try assumption.

--- a/TypeTheory/OtherDefs/CwF_Dybjer.v
+++ b/TypeTheory/OtherDefs/CwF_Dybjer.v
@@ -16,8 +16,7 @@ Require Import TypeTheory.Auxiliary.Auxiliary.
 Require Import TypeTheory.Auxiliary.CategoryTheoryImports.
 Require Import TypeTheory.Categories.category_FAM.
 
-
-Local Notation "C '^op'" := (opp_precat C) (at level 3, format "C ^op").
+Local Open Scope precat.
 Local Notation "# F" := (functor_on_morphisms F)(at level 3).
 Local Notation "C ⦃ a , b ⦄" := (precategory_morphisms (C:=C) a b) (at level 50).
 (** * A "preview" of the definition *)
@@ -33,8 +32,8 @@ Reserved Notation "'π' A" (at level 20).
 Reserved Notation "'ν' A" (at level 15).
 Reserved Notation "γ ♯ a" (at level 25).
 
-Notation "A ₁" := (index_type _ A)(at level 3).
-Notation "A ₂" := (index_func _ A)(at level 3).
+Notation "A ₁" := (index_type A)(at level 3).
+Notation "A ₂" := (index_func A)(at level 3).
 
 Record precwf_record : Type := {
   C :> precategory ;

--- a/TypeTheory/OtherDefs/CwF_Pitts.v
+++ b/TypeTheory/OtherDefs/CwF_Pitts.v
@@ -5,7 +5,7 @@
 
   Contents:
 
-    - Definition of a precategory with families
+    - Definition of a category with families
     - Proof that reindexing forms a pullback
 
   The definition is based on Pitts, *Nominal Presentations of the Cubical Sets
@@ -36,8 +36,8 @@ Reserved Notation "'π' A" (at level 20).
 Reserved Notation "'ν' A" (at level 15).
 Reserved Notation "γ ♯ a" (at level 25).
 
-Record precwf_record : Type := {
-  C : precategory ;
+Record cwf_record : Type := {
+  C : category ;
   type : C → UU     where "C ⟨ Γ ⟩" := (type Γ) ;
   term : ∏ Γ : C, C⟨Γ⟩ → UU     where "C ⟨ Γ ⊢ A ⟩" := (term Γ A) ;
   rtype : ∏ {Γ Γ' : C} (A : C⟨Γ⟩) (γ : Γ' --> Γ), C⟨Γ'⟩ where "A {{ γ }}" := (rtype A γ) ;
@@ -78,31 +78,31 @@ End Record_Preview.
 
 (** * Type and terms of a [CwF] *)
 (** 
- A [tt_precategory] comes with a types, written [C⟨Γ⟩], 
+ A [tt_category] comes with a types, written [C⟨Γ⟩], 
    and terms [C⟨Γ ⊢ A⟩] 
 *)
 
-Definition tt_structure (C : precategory) :=
+Definition tt_structure (C : category) :=
   ∑ f : C → UU, ∏ c : C, f c → UU.
 
 
-Definition type {C : precategory} (TT : tt_structure C) : C → UU := pr1 TT.
+Definition type {C : category} (TT : tt_structure C) : C → UU := pr1 TT.
 
 Notation "C ⟨ Γ ⟩" := (type C Γ) (at level 60).
   (* \< and \> in Agda input method *)
 
-Definition term {CC : precategory} (C : tt_structure CC) : ∏ Γ : CC, C⟨Γ⟩ → UU := pr2 C.
+Definition term {CC : category} (C : tt_structure CC) : ∏ Γ : CC, C⟨Γ⟩ → UU := pr2 C.
 
 Notation "C ⟨ Γ ⊢ A ⟩" := (term C Γ A) (at level 60).
   (* \<, \>, and \|- or \vdash *)
 
 (** * Reindexing of types [A{{γ]] and terms [a⟦γ⟧] along a morphism [γ : Γ' --> Γ] *)
 
-Definition reindx_structure {CC : precategory}(C : tt_structure CC) := 
+Definition reindx_structure {CC : category}(C : tt_structure CC) := 
    ∑ (rtype : ∏ {Γ Γ' : CC} (A : C⟨Γ⟩) (γ : Γ' --> Γ), C⟨Γ'⟩),
         ∏ (Γ Γ' : CC) (A : C⟨Γ⟩) (a : C⟨Γ⊢A⟩) (γ : Γ' --> Γ), C⟨Γ'⊢rtype A γ⟩.
 
-Definition tt_reindx_struct (CC : precategory) : UU 
+Definition tt_reindx_struct (CC : category) : UU 
  :=
    ∑ C : tt_structure CC, reindx_structure C.
 
@@ -110,14 +110,14 @@ Coercion tt_from_tt_reindx CC (C : tt_reindx_struct CC) : tt_structure _ := pr1 
 Coercion reindx_from_tt_reindx CC (C : tt_reindx_struct CC) : reindx_structure _ := pr2 C.
 
 
-Definition rtype {CC : precategory}{C : tt_reindx_struct CC} 
+Definition rtype {CC : category}{C : tt_reindx_struct CC} 
   : ∏ {Γ Γ' : CC} (A : C⟨Γ⟩) (γ : Γ' --> Γ), C⟨Γ'⟩ 
 := 
    pr1 (pr2 C).
 
 Notation "A {{ γ }}" := (rtype A γ) (at level 30).
 
-Definition rterm {CC : precategory}{C : tt_reindx_struct CC}  
+Definition rterm {CC : category}{C : tt_reindx_struct CC}  
   : ∏ {Γ Γ' : CC} {A : C⟨Γ⟩}  (a : C⟨Γ⊢A⟩) (γ : Γ' --> Γ), C⟨Γ'⊢ A {{γ}} ⟩ 
 := 
     pr2 (pr2 C).
@@ -127,12 +127,12 @@ Notation "a ⟦ γ ⟧" := (rterm a γ) (at level 40).
 (** *  Reindexing laws *)
 
 (** Reindexing for types *)
-Definition reindx_laws_type {CC : precategory}(C : tt_reindx_struct CC) : UU :=
+Definition reindx_laws_type {CC : category}(C : tt_reindx_struct CC) : UU :=
     (∏ Γ (A : C⟨Γ⟩), A {{identity Γ}} = A) ×
     (∏ Γ Γ' Γ'' (γ : Γ' --> Γ) (γ' : Γ'' --> Γ') (A : C⟨Γ⟩), A {{γ';;γ}} = A{{γ}}{{γ'}}). 
 
 (** Reindexing for terms needs transport along reindexing for types *) 
-Definition reindx_laws_terms {CC : precategory} {C : tt_reindx_struct CC} 
+Definition reindx_laws_terms {CC : category} {C : tt_reindx_struct CC} 
     (T : reindx_laws_type C) :=
     (∏ Γ (A : C⟨Γ⟩) (a : C⟨Γ⊢A⟩), a⟦identity Γ⟧ = 
           transportf (λ B, C⟨Γ ⊢ B⟩) (!pr1 T _ _) a) ×
@@ -141,29 +141,29 @@ Definition reindx_laws_terms {CC : precategory} {C : tt_reindx_struct CC}
           transportf (λ B, C⟨Γ'' ⊢ B⟩) (!pr2 T _ _ _ _ _ _ )  (a⟦γ⟧⟦γ'⟧)).
           
 (** Package of reindexing for types and terms *)
-Definition reindx_laws {CC : precategory} (C : tt_reindx_struct CC)  : UU := 
+Definition reindx_laws {CC : category} (C : tt_reindx_struct CC)  : UU := 
    ∑ T : reindx_laws_type C, reindx_laws_terms T.
      
-Definition reindx_type_id {CC : precategory} {C : tt_reindx_struct CC} 
+Definition reindx_type_id {CC : category} {C : tt_reindx_struct CC} 
     (T : reindx_laws C)
   : ∏ Γ (A : C⟨Γ⟩), A {{identity Γ}} = A 
 := 
   pr1 (pr1 T).
 
-Definition reindx_type_comp {CC : precategory} {C : tt_reindx_struct CC} 
+Definition reindx_type_comp {CC : category} {C : tt_reindx_struct CC} 
     (T : reindx_laws C) 
    {Γ Γ' Γ''} (γ : Γ' --> Γ) (γ' : Γ'' --> Γ') (A : C⟨Γ⟩) 
   : A {{γ';;γ}} = A{{γ}}{{γ'}} 
 :=
    pr2 (pr1 T) _ _ _ _ _ _ .
 
-Definition reindx_term_id {CC : precategory} {C : tt_reindx_struct CC}
+Definition reindx_term_id {CC : category} {C : tt_reindx_struct CC}
    (T : reindx_laws C) 
   : ∏ Γ (A : C⟨Γ⟩) (a : C⟨Γ⊢A⟩), a⟦identity Γ⟧ = 
           transportf (λ B, C⟨Γ ⊢ B⟩) (!pr1 (pr1 T) _ _) a 
 := pr1 (pr2 T).
 
-Definition reindx_term_comp {CC : precategory} {C : tt_reindx_struct CC}
+Definition reindx_term_comp {CC : category} {C : tt_reindx_struct CC}
     (T : reindx_laws C) 
   : ∏ {Γ Γ' Γ''} (γ : Γ' --> Γ) (γ' : Γ'' --> Γ') {A : C⟨Γ⟩} (a : C⟨Γ⊢A⟩),
             a⟦γ';;γ⟧ = 
@@ -176,25 +176,25 @@ Definition reindx_term_comp {CC : precategory} {C : tt_reindx_struct CC}
 
 (** ** Comprehension object and projection *)
 
-Definition comp_1_struct {CC : precategory} (C : tt_reindx_struct CC) : UU 
+Definition comp_1_struct {CC : category} (C : tt_reindx_struct CC) : UU 
 :=
   ∏ Γ (A : C⟨Γ⟩), ∑ ΓA, ΓA --> Γ.
 
 
-Definition tt_reindx_comp_1_struct (CC : precategory) : UU 
+Definition tt_reindx_comp_1_struct (CC : category) : UU 
   := 
      ∑ C : tt_reindx_struct CC, comp_1_struct C.
 
-Coercion tt_reindx_from_tt_reindx_comp_1 (CC : precategory) (C : tt_reindx_comp_1_struct CC) 
+Coercion tt_reindx_from_tt_reindx_comp_1 (CC : category) (C : tt_reindx_comp_1_struct CC) 
   : tt_reindx_struct _ := pr1 C.
 
-Definition comp_obj {CC : precategory} {C : tt_reindx_comp_1_struct CC} (Γ : CC) (A : C⟨Γ⟩) 
+Definition comp_obj {CC : category} {C : tt_reindx_comp_1_struct CC} (Γ : CC) (A : C⟨Γ⟩) 
   : CC 
 :=  (pr1 (pr2 C Γ A)).
 Notation "Γ ∙ A" := (comp_obj Γ A) (at level 35).
   (* \. in Adga mode *)
 
-Definition proj_mor {CC : precategory} {C : tt_reindx_comp_1_struct CC}
+Definition proj_mor {CC : category} {C : tt_reindx_comp_1_struct CC}
       {Γ : CC} (A : C⟨Γ⟩) 
   : Γ ∙ A  --> Γ 
 := (pr2 (pr2 C Γ A)).
@@ -202,21 +202,21 @@ Definition proj_mor {CC : precategory} {C : tt_reindx_comp_1_struct CC}
 Notation "'π' A" := (proj_mor A) (at level 20).
 
 (** ** Generic element and pairing *)
-Definition comp_2_struct {CC : precategory} (C : tt_reindx_comp_1_struct CC) : UU
+Definition comp_2_struct {CC : category} (C : tt_reindx_comp_1_struct CC) : UU
 := 
    ∏ Γ (A : C⟨Γ⟩), 
      C⟨(Γ∙A) ⊢ (A {{π A}}) ⟩ × 
      (∏ Γ' (γ : Γ' --> Γ) (a : C⟨Γ'⊢A{{γ}}⟩), Γ' --> Γ∙A).
 
-Definition tt_reindx_type_struct (CC : precategory) : UU 
+Definition tt_reindx_type_struct (CC : category) : UU 
 :=
    ∑ C : tt_reindx_comp_1_struct CC, comp_2_struct C.
 
-Coercion tt_reindx_comp_1_from_tt_reindx_comp (CC : precategory) (C : tt_reindx_type_struct CC) 
+Coercion tt_reindx_comp_1_from_tt_reindx_comp (CC : category) (C : tt_reindx_type_struct CC) 
   : tt_reindx_comp_1_struct _ := pr1 C.
 
 
-Definition gen_elem  {CC : precategory} {C : tt_reindx_type_struct CC} 
+Definition gen_elem  {CC : category} {C : tt_reindx_type_struct CC} 
     {Γ : CC} (A : C⟨Γ⟩) 
   : C⟨Γ∙A  ⊢ A{{π _ }}⟩ 
  := 
@@ -224,7 +224,7 @@ Definition gen_elem  {CC : precategory} {C : tt_reindx_type_struct CC}
 
 Notation "'ν' A" := (gen_elem A) (at level 15).
 
-Definition pairing  {CC : precategory} {C : tt_reindx_type_struct CC} 
+Definition pairing  {CC : category} {C : tt_reindx_type_struct CC} 
     {Γ : CC} {A : C⟨Γ⟩} {Γ'} (γ : Γ' --> Γ) (a : C⟨Γ'⊢A{{γ}}⟩) 
   : Γ' --> Γ∙A  
 := pr2 (pr2 C Γ A) Γ' γ a.
@@ -235,7 +235,7 @@ Notation "γ ♯ a" := (pairing γ a) (at level 25).
 
 (** ** Laws satisfied by the comprehension structure *)
 
-Definition comp_laws_1_2  {CC : precategory} {C : tt_reindx_type_struct CC} 
+Definition comp_laws_1_2  {CC : category} {C : tt_reindx_type_struct CC} 
    (L : reindx_laws C) : UU := 
    ∏ Γ (A : C ⟨Γ⟩) Γ' (γ : Γ' --> Γ) (a : C⟨Γ'⊢ A{{γ}}⟩),
         ∑ h : (γ ♯ a) ;; (π _ ) = γ,
@@ -243,7 +243,7 @@ Definition comp_laws_1_2  {CC : precategory} {C : tt_reindx_type_struct CC}
              (transportf (λ B, C⟨Γ'⊢ B⟩) (!reindx_type_comp L (π _ )(γ ♯ a) _ )
                ((ν _ ) ⟦γ ♯ a⟧)) = a.
 
-Definition comp_law_3  {CC : precategory} {C : tt_reindx_type_struct CC}
+Definition comp_law_3  {CC : category} {C : tt_reindx_type_struct CC}
      (L : reindx_laws C) : UU 
 := 
    ∏ Γ (A : C ⟨Γ⟩) Γ' Γ'' (γ : Γ' --> Γ) (γ' : Γ'' --> Γ') (a : C⟨Γ'⊢ A{{γ}}⟩),
@@ -251,7 +251,7 @@ Definition comp_law_3  {CC : precategory} {C : tt_reindx_type_struct CC}
     =  
     (γ' ;; γ) ♯ (transportf (λ B, C⟨Γ''⊢ B⟩) (!reindx_type_comp L γ γ' _ ) (a⟦γ'⟧)).
 
-Definition comp_law_4  {CC : precategory} {C : tt_reindx_type_struct CC}
+Definition comp_law_4  {CC : category} {C : tt_reindx_type_struct CC}
     (L : reindx_laws C) : UU
 :=
    ∏ Γ (A : C⟨Γ⟩), π A ♯ ν A = identity _ . 
@@ -259,15 +259,16 @@ Definition comp_law_4  {CC : precategory} {C : tt_reindx_type_struct CC}
 
 
 
-Definition cwf_laws {CC : precategory}(C : tt_reindx_type_struct CC) 
+Definition cwf_laws {CC : category} (C : tt_reindx_type_struct CC) 
    :=
     (∑ T : reindx_laws C,
-       (comp_laws_1_2 T × comp_law_3 T × comp_law_4 T)) ×
-    (has_homsets CC × (∏ Γ, isaset (C⟨Γ⟩)) × ∏ Γ (A : C⟨Γ⟩), isaset (C⟨Γ⊢ A⟩)). 
+       (comp_laws_1_2 T × comp_law_3 T × comp_law_4 T))
+    × (∏ Γ, isaset (C⟨Γ⟩))
+    × ∏ Γ (A : C⟨Γ⟩), isaset (C⟨Γ⊢ A⟩). 
 
-(** * Definition of precategory with families *)
-(** A precategory with families [pre_cwf] is 
-  - a precategory
+(** * Definition of category with families *)
+(** A category with families [pre_cwf] is 
+  - a category
   - with type-and-term structure 
   - with reindexing 
   - with comprehension structure
@@ -276,7 +277,7 @@ Definition cwf_laws {CC : precategory}(C : tt_reindx_type_struct CC)
 *)
 
 
-Definition cwf_struct (CC : precategory) : UU 
+Definition cwf_struct (CC : category) : UU 
   := ∑ C : tt_reindx_type_struct CC, cwf_laws C.
 
 (** * Various access functions to the components *)
@@ -284,36 +285,32 @@ Definition cwf_struct (CC : precategory) : UU
     generalized proofs of identity of types, terms (which form hsets) 
 *)
 
-Coercion cwf_data_from_cwf_struct (CC : precategory) (C : cwf_struct CC) : _ CC := pr1 C.
-Coercion cwf_laws_from_cwf_struct (CC : precategory) (C : cwf_struct CC) : cwf_laws C := pr2 C.
+Coercion cwf_data_from_cwf_struct (CC : category) (C : cwf_struct CC) : _ CC := pr1 C.
+Coercion cwf_laws_from_cwf_struct (CC : category) (C : cwf_struct CC) : cwf_laws C := pr2 C.
 
 
-Coercion reindx_laws_from_cwf_struct (CC : precategory) (C : cwf_struct CC)
+Coercion reindx_laws_from_cwf_struct (CC : category) (C : cwf_struct CC)
   : reindx_laws C
   := pr1 (pr1 (pr2 C)).
 
 
-Definition cwf_comp_laws {CC : precategory} (C : cwf_struct CC)
+Definition cwf_comp_laws {CC : category} (C : cwf_struct CC)
   : (comp_laws_1_2 C × comp_law_3 C × comp_law_4 C)
   := pr2 (pr1 (pr2 C)).
 
+Definition cwf_types_isaset {CC : category} (C : cwf_struct CC) Γ : isaset (C⟨Γ⟩)
+  := pr1 (pr2 (pr2 C)) Γ.
 
-Definition has_homsets_cwf {CC : precategory} (C : cwf_struct CC) : has_homsets CC
-  := pr1 (pr2 (pr2 C)).
-
-Definition cwf_types_isaset {CC : precategory} (C : cwf_struct CC) Γ : isaset (C⟨Γ⟩)
-  := pr1 (pr2 (pr2 (pr2 C))) Γ.
-
-Definition cwf_terms_isaset  {CC : precategory} (C : cwf_struct CC) : ∏ Γ A, isaset (C⟨Γ ⊢ A⟩)
-  := pr2 (pr2 (pr2 (pr2 C))).
+Definition cwf_terms_isaset  {CC : category} (C : cwf_struct CC) : ∏ Γ A, isaset (C⟨Γ ⊢ A⟩)
+  := pr2 (pr2 (pr2 C)).
 
 
-Definition cwf_law_1 {CC : precategory} (C : cwf_struct CC) 
+Definition cwf_law_1 {CC : category} (C : cwf_struct CC) 
   Γ (A : C ⟨Γ⟩) Γ' (γ : Γ' --> Γ) (a : C⟨Γ'⊢ A{{γ}}⟩)
   : (γ ♯ a) ;; (π _) = γ
   :=  pr1 (pr1 (cwf_comp_laws C) Γ A Γ' γ a).
 
-Definition cwf_law_2 {CC : precategory} (C : cwf_struct CC) 
+Definition cwf_law_2 {CC : category} (C : cwf_struct CC) 
   Γ (A : C ⟨Γ⟩) Γ' (γ : Γ' --> Γ) (a : C⟨Γ'⊢ A{{γ}}⟩)
   : transportf (λ ι, C⟨Γ'⊢ A {{ι}}⟩) (cwf_law_1 C Γ A Γ' γ a)
     (transportf (λ B, C⟨Γ'⊢ B⟩) (!reindx_type_comp C (π _)(γ ♯ a) _ ) 
@@ -321,7 +318,7 @@ Definition cwf_law_2 {CC : precategory} (C : cwf_struct CC)
     = a
   := pr2 ((pr1 (cwf_comp_laws C)) Γ A Γ' γ a).
 
-Definition cwf_law_2_gen {CC : precategory} (C : cwf_struct CC) 
+Definition cwf_law_2_gen {CC : category} (C : cwf_struct CC) 
   Γ (A : C ⟨Γ⟩) Γ' (γ : Γ' --> Γ) (a : C⟨Γ'⊢ A{{γ}}⟩)
   :  ∏ (p : (A {{π A}}) {{γ ♯ a}} = A {{γ ♯ a;; π A}}) (p0 : γ ♯ a;; π A = γ),
    transportf (λ ι : Γ' --> Γ, C ⟨ Γ' ⊢ A {{ι}} ⟩) p0
@@ -330,17 +327,17 @@ Proof.
   intros p p'.
   etrans; [ | apply cwf_law_2].
   match goal with | [ |- _ = transportf _ ?p1 _ ] => assert (T : p' = p1) end. 
-  { apply (has_homsets_cwf C). }
+  { apply homset_property. }
   rewrite T; clear T. apply maponpaths.
   match goal with | [ |- _ = transportf _ ?p1 _ ] => assert (T : p = p1) end.
   { apply (cwf_types_isaset C). }
   rewrite T; apply idpath.
 Qed.  
 
-Definition cwf_law_3 {CC : precategory} (C : cwf_struct CC) : comp_law_3 C
+Definition cwf_law_3 {CC : category} (C : cwf_struct CC) : comp_law_3 C
   :=  pr1 (pr2 (cwf_comp_laws C)).
 
-Definition cwf_law_3_gen {CC : precategory} (C : cwf_struct CC) 
+Definition cwf_law_3_gen {CC : category} (C : cwf_struct CC) 
   (Γ : CC) (A : C ⟨ Γ ⟩) (Γ' Γ'' : CC) (γ : Γ' --> Γ) (γ' : Γ'' --> Γ')
   (a : C ⟨ Γ' ⊢ A {{γ}} ⟩) (p : (A {{γ}}) {{γ'}} = A {{γ';; γ}}):
    γ';; γ ♯ a =
@@ -353,13 +350,13 @@ Proof.
   rewrite T; apply idpath.
 Qed.
 
-Definition cwf_law_4 {CC : precategory} (C : cwf_struct CC) : comp_law_4 C
+Definition cwf_law_4 {CC : category} (C : cwf_struct CC) : comp_law_4 C
   := pr2 (pr2 (cwf_comp_laws C)).
 
 
 Ltac imp := apply impred; intro.
 
-Lemma isPredicate_cwf_laws (CC : precategory)
+Lemma isPredicate_cwf_laws (CC : category)
 : isPredicate (@cwf_laws CC).
 Proof.
   intros T.
@@ -391,14 +388,13 @@ Proof.
         {
           do 5 imp.
           apply (isofhleveltotal2 1).
-          - apply (has_homsets_cwf X).
+          - apply homset_property.
           - intros. apply (cwf_terms_isaset X).
         }
-      * do 7 imp. apply (has_homsets_cwf X).
-      * do 2 imp. apply (has_homsets_cwf X).
+      * do 7 imp. apply homset_property.
+      * do 2 imp. apply homset_property.
   - intros.
-    repeat (apply isofhleveldirprod).
-    + apply isaprop_has_homsets.
+    apply isofhleveldirprod.
     + do 1 imp. apply isapropisaset.
     + do 2 imp. apply isapropisaset.
 Qed.
@@ -410,7 +406,7 @@ Section CwF_lemmas.
 Generalizable Variable CC.
 Context `{C : cwf_struct CC}.
 
-Lemma map_to_comp_as_pair_precwf {Γ} {A : C⟨Γ⟩} {Γ'} (f : Γ' --> Γ∙A)
+Lemma map_to_comp_as_pair_cwf {Γ} {A : C⟨Γ⟩} {Γ'} (f : Γ' --> Γ∙A)
   :   (f ;; π A) ♯ (transportb _ (reindx_type_comp C _ _ _) ((gen_elem A)⟦f⟧))
       = 
       f.
@@ -537,7 +533,7 @@ Proof.
   apply id_right.
 Defined.
 
-Definition q_precwf {Γ} (A : C ⟨ Γ ⟩ ) {Γ'} (f : Γ' --> Γ)
+Definition q_cwf {Γ} (A : C ⟨ Γ ⟩ ) {Γ'} (f : Γ' --> Γ)
   : (comp_obj  Γ' (A{{f}})) --> (Γ ∙ A).
 Proof.
   set (T:= @pairing _ C).
@@ -546,12 +542,12 @@ Proof.
   apply gen_elem.
 Defined.
 
-Definition dpr_q_precwf 
+Definition dpr_q_cwf 
   {Γ} (A : C ⟨ Γ ⟩)
   {Γ'} (f : Γ' --> Γ)
-: (q_precwf A f) ;; (π A) = (π (A{{f}})) ;; f.
+: (q_cwf A f) ;; (π A) = (π (A{{f}})) ;; f.
 Proof.
-  unfold q_precwf.
+  unfold q_cwf.
   apply cwf_law_1.
 Qed.
 
@@ -559,9 +555,9 @@ Qed.
 Lemma rterm_univ {Γ} {A : C ⟨ Γ ⟩} {Γ'} (f : Γ' --> Γ)
   : ν (A{{f}})
    = transportf _ (reindx_type_comp C _ _ _)
-       (transportf _ (maponpaths (fun g => A{{g}}) (dpr_q_precwf A f))
+       (transportf _ (maponpaths (fun g => A{{g}}) (dpr_q_cwf A f))
          (transportb _ (reindx_type_comp C _ _ _)
-            ((ν A)⟦q_precwf A f⟧))).
+            ((ν A)⟦q_cwf A f⟧))).
 Proof.
   sym.
   rew_trans_@.
@@ -583,7 +579,7 @@ We split this up into several lemmas:
 
 *)
 
-Definition dpr_q_pbpairing_precwf_aux
+Definition dpr_q_pbpairing_cwf_aux
   {Γ} (A : C ⟨ Γ ⟩)
   {Γ'} (f : Γ' --> Γ)
   {X} (h : X --> Γ ∙ A) (k : X --> Γ') (H : h ;; π A = k ;; f)
@@ -597,16 +593,16 @@ Definition dpr_q_pbpairing_commutes
   {Γ} (A : C ⟨ Γ ⟩)
   {Γ'} (f : Γ' --> Γ)
   {X} (h : X --> Γ ∙ A) (k : X --> Γ') (H : h ;; π A = k ;; f)
-  (hk := @pairing _ C Γ' (A{{f}}) X k (dpr_q_pbpairing_precwf_aux A f h k H))
-: (hk ;; q_precwf A f = h) × (hk ;; π (A{{f}}) = k).
+  (hk := @pairing _ C Γ' (A{{f}}) X k (dpr_q_pbpairing_cwf_aux A f h k H))
+: (hk ;; q_cwf A f = h) × (hk ;; π (A{{f}}) = k).
 Proof.
   split. 2: { apply cwf_law_1. }
-  unfold q_precwf.
+  unfold q_cwf.
   etrans.
-  2: { apply map_to_comp_as_pair_precwf. }
+  2: { apply map_to_comp_as_pair_cwf. }
   etrans.
   { apply cwf_law_3. }
-  assert ((k ♯ (dpr_q_pbpairing_precwf_aux A f h k H)) ;; (π (A {{f}}) ;; f) 
+  assert ((k ♯ (dpr_q_pbpairing_cwf_aux A f h k H)) ;; (π (A {{f}}) ;; f) 
           = h ;; π A) as e1.
     eapply pathscomp0. apply assoc.
     refine (_ @ !H).
@@ -625,30 +621,30 @@ Proof.
   apply cwf_types_isaset.
 Qed.
 
-Definition dpr_q_pbpairing_precwf
+Definition dpr_q_pbpairing_cwf
   {Γ} (A : C ⟨ Γ ⟩)
   {Γ'} (f : Γ' --> Γ)
   {X} (h : X --> Γ ∙ A) (k : X --> Γ') (H : h ;; π A = k ;; f)
 : ∑ (hk : X --> Γ' ∙ (A{{f}})),
-    ( hk ;; q_precwf A f = h
+    ( hk ;; q_cwf A f = h
     × hk ;; π (A{{f}}) = k).
 Proof.
-  exists (@pairing _ C Γ' (A{{f}}) X k (dpr_q_pbpairing_precwf_aux A f h k H)).
+  exists (@pairing _ C Γ' (A{{f}}) X k (dpr_q_pbpairing_cwf_aux A f h k H)).
   apply dpr_q_pbpairing_commutes.
 Defined.
 
 
-Definition dpr_q_pbpairing_precwf_mapunique
+Definition dpr_q_pbpairing_cwf_mapunique
   {Γ} (A : C⟨Γ⟩)
   {Γ'} (f : Γ' --> Γ)
   {X} {h : X --> Γ ∙ A} {k : X --> Γ'} (H : h ;; π A = k ;; f)
   (hk : X --> Γ' ∙ (A {{f}}))
-  (e2 : hk ;; q_precwf A f = h)
+  (e2 : hk ;; q_cwf A f = h)
   (e1 : hk ;; π (A{{f}}) = k)
-: hk = pr1 (dpr_q_pbpairing_precwf A f h k H).
+: hk = pr1 (dpr_q_pbpairing_cwf A f h k H).
 Proof.
   eapply pathscomp0.
-    eapply pathsinv0. apply map_to_comp_as_pair_precwf.
+    eapply pathsinv0. apply map_to_comp_as_pair_cwf.
   eapply pathscomp0.
     apply (pairing_mapeq _ _ e1 _).
   simpl. apply maponpaths.
@@ -680,29 +676,29 @@ Proof.
   apply idpath.
 Qed.
 
-Definition dpr_q_pbpairing_precwf_unique (hs : has_homsets CC)
+Definition dpr_q_pbpairing_cwf_unique (hs : has_homsets CC)
   {Γ} (A : C⟨Γ⟩)
   {Γ'} (f : Γ' --> Γ)
   {X} (h : X --> Γ ∙ A) (k : X --> Γ') (H : h ;; π A = k ;; f)
   (t : ∑ hk : X --> Γ' ∙ (A {{f}}),
-       (hk ;; q_precwf A f = h) × (hk ;; π (A{{f}}) = k))
-: t = dpr_q_pbpairing_precwf A f h k H.
+       (hk ;; q_cwf A f = h) × (hk ;; π (A{{f}}) = k))
+: t = dpr_q_pbpairing_cwf A f h k H.
 Proof.
   destruct t as [hk [e2 e1]]. 
   refine (@total2_paths_f _ _ (tpair _ hk (tpair _ e2 e1)) _ 
-    (dpr_q_pbpairing_precwf_mapunique A f H hk e2 e1) _).
+    (dpr_q_pbpairing_cwf_mapunique A f H hk e2 e1) _).
   unshelve refine (total2_paths_f _ _); apply hs.
 Qed.
 
 Lemma is_pullback_reindx_cwf (hs : has_homsets CC) : ∏ (Γ : CC) (A : C⟨Γ⟩) (Γ' : CC) 
    (f : Γ' --> Γ),
-   isPullback (π A) f (q_precwf A f) (π (A {{f}})) (dpr_q_precwf A f).
+   isPullback (dpr_q_cwf A f).
 Proof.
   intros.
   apply make_isPullback; try assumption.
   intros e h k H.
-  exists (dpr_q_pbpairing_precwf _ _ h k H).
-  apply dpr_q_pbpairing_precwf_unique.
+  exists (dpr_q_pbpairing_cwf _ _ h k H).
+  apply dpr_q_pbpairing_cwf_unique.
   assumption.
 Defined.
   

--- a/TypeTheory/OtherDefs/CwF_Pitts_completion.v
+++ b/TypeTheory/OtherDefs/CwF_Pitts_completion.v
@@ -22,17 +22,17 @@ Arguments iso: clear implicits.
 
 (** How to get a functor from RC(C) to D when having one from C to D **)
 
-Definition Rezk_functor (C : precategory) (hs : has_homsets C) (D : univalent_category) 
+Definition Rezk_functor (C : category) (D : univalent_category) 
     (F : functor C D) 
-  :  functor (Rezk_completion C hs) D.
+  :  functor (Rezk_completion C) D.
 Proof.
-  set (H:=Rezk_eta_Universal_Property C hs D  (pr2 D)).
+  set (H:=Rezk_eta_Universal_Property C D  (pr2 D)).
   apply (invmap (make_weq _  H)).
   apply F.
 Defined.
 
 (** The opposite precategory of a saturated category is saturated. **)
-
+(* TODO: this section probably now provided by UniMath; remove if so, otherwise upstream *)
 Definition opp_iso_inv {C : precategory} {a b : C} : iso (opp_precat C) a b → iso C b a.
 Proof.
   intro f.
@@ -68,32 +68,31 @@ Proof.
   - apply opp_iso_opp_iso_inv.
 Defined.
 
-Definition isotoid_opp (C : precategory) (H : is_univalent C) (a b : opp_precat C) : 
-   weq (a = b) (iso (opp_precat C) a b).
+Definition isotoid_opp (C : category) (H : is_univalent C) (a b : opp_precat C) : 
+   weq (a = b) (iso (C^op) a b).
 Proof.
   eapply weqcomp.
   - apply weqpathsinv0.
   - eapply weqcomp.
-    + apply (make_weq (@idtoiso C b a) (pr1 H b a)).
+    + apply (make_weq (@idtoiso C b a) (H b a)).
     + apply weq_opp_iso.
 Defined.
 
 
-Definition is_univalent_opp (C : precategory) (H : is_univalent C) : is_univalent (opp_precat C).
+Definition is_univalent_opp (C : category) (H : is_univalent C) : is_univalent C^op.
 Proof.
-  split; intros; simpl in *.
-  - set (H1:=@isweqhomot).
-    set (H2 := H1 _ _ (isotoid_opp C H a b)).
-    apply H2.
-    intro t; induction t.
-    apply eq_iso; apply idpath.
-    apply (pr2 (isotoid_opp C H a b)).
-  - intros a b. apply (pr2 H).
+  intros a b.
+  set (H1:=@isweqhomot).
+  set (H2 := H1 _ _ (isotoid_opp C H a b)).
+  apply H2.
+  intro t; induction t.
+  apply eq_iso; apply idpath.
+  apply (pr2 (isotoid_opp C H a b)).
 Qed.
  
 Definition opp_univalent_cat (C : univalent_category) : univalent_category.
 Proof.
-  exists (opp_precat C).
+  exists C^op.
   apply is_univalent_opp.
   apply (pr2 C).
 Defined.
@@ -103,7 +102,7 @@ Defined.
 
 Section CwF_completion.
 
-Context (CC : precategory) (C : cwf_struct CC).
+Context (CC : category) (C : cwf_struct CC).
 
 (** ** The "type" part of a CwF **)
 
@@ -131,9 +130,9 @@ Qed.
 
 Definition type_functor : functor _ _ := tpair _ _ type_is_functor.
 
-Definition RC_type_functor : functor (Rezk_completion CC (has_homsets_cwf C)) (opp_precat HSET).
+Definition RC_type_functor : functor (Rezk_completion CC) (opp_precat HSET).
 Proof.  
-  apply (Rezk_functor CC _ (opp_univalent_cat HSET_univalent_category)).
+  apply (Rezk_functor CC (opp_univalent_cat HSET_univalent_category)).
   apply type_functor.
 Defined.
   

--- a/TypeTheory/OtherDefs/CwF_Pitts_to_DM.v
+++ b/TypeTheory/OtherDefs/CwF_Pitts_to_DM.v
@@ -32,7 +32,7 @@ Local Notation "γ ## a" := (pairing γ a) (at level 75).
 Section DM_of_CwF.
 
 (** assumption of [CC] being saturated is essential: we need pullbacks to be propositions *)
-Context (CC : precategory) (C : cwf_struct CC) (H : is_univalent CC).
+Context (CC : category) (C : cwf_struct CC) (H : is_univalent CC).
 
 (** Being isomorphic to a dependent projection *)
 Definition iso_to_dpr {Γ Γ'} (γ : Γ --> Γ') : UU
@@ -90,19 +90,19 @@ Proof.
   destruct T as [A [h e]].
   clear B.
   unshelve refine (tpair _ _ _ ).
-  - unshelve refine (make_Pullback _ _ _ _ _ _ _ ).
+  - unshelve refine (make_Pullback _ _).
     + apply (Γ' ∙ (A{{f}})).
-    + apply (q_precwf _ _ ;; h).
+    + apply (q_cwf _ _ ;; h).
     + apply (π _ ). 
     + simpl. unfold dm_sub_struct_of_CwF.
       simpl.
-      set (T:= postcomp_pb_with_iso CC (pr2 H)).
-      set (T':= T _ _ _ _  (q_precwf A f) _ _ f _ (is_pullback_reindx_cwf (pr2 H) _ _ _ _ )).
+      set (T:= postcomp_pb_with_iso CC).
+      set (T':= T (homset_property _) _ _ _ _ (q_cwf A f) _ _ f _ (is_pullback_reindx_cwf (homset_property _) _ _ _ _ )).
       refine (pr1 (T' _ _ _ _ )).
       sym. assumption.
     + 
-      set (T:= postcomp_pb_with_iso CC (pr2 H)).
-      set (T':= T _ _ _ _  (q_precwf A f) _ _ f _ (is_pullback_reindx_cwf (pr2 H) _ _ _ _ )).
+      set (T:= postcomp_pb_with_iso CC (homset_property _)).
+      set (T':= T _ _ _ _  (q_cwf A f) _ _ f _ (is_pullback_reindx_cwf (homset_property _) _ _ _ _ )).
       eapply (pr2 (T' _ _ _ _ )).
   - simpl.
     apply hinhpr.

--- a/TypeTheory/OtherDefs/CwF_Pitts_to_TypeCat.v
+++ b/TypeTheory/OtherDefs/CwF_Pitts_to_TypeCat.v
@@ -5,8 +5,8 @@
 
 Contents:
 
-  - Construction of a type-precategory from a precategory with Families
-  - Proof that the constructed type-precategory is split
+  - Construction of a type-category from a category with Families
+  - Proof that the constructed type-category is split
 
 *)
 
@@ -27,7 +27,7 @@ Local Notation "γ ## a" := (pairing γ a) (at level 75).
 Section Prelims.
 
 (* TODO: move to [cwf] *)
-Definition pairing_transport {CC : precategory} (C : cwf_struct CC) {Γ} {A A' : C⟨Γ⟩} (e : A = A')
+Definition pairing_transport {CC : category} (C : cwf_struct CC) {Γ} {A A' : C⟨Γ⟩} (e : A = A')
   {Γ'} (γ : Γ' --> Γ) (a : C ⟨Γ'⊢A{{γ}}⟩)
 : (γ ## a) ;; idtoiso (maponpaths (fun (B : C⟨Γ⟩) => Γ∙B) e)
 = (γ ## (transportf (fun B => C ⟨ Γ' ⊢ B {{γ}}⟩) e a)).
@@ -37,7 +37,7 @@ Proof.
 Defined.
 
 (* TODO: generalise; really it’s about any [transportf] along any [maponpaths]. *)
-Lemma transportf_maponpaths {CC : precategory} {C : cwf_struct CC} {Γ} {B B' : C⟨Γ⟩} (e : B = B')
+Lemma transportf_maponpaths {CC : category} {C : cwf_struct CC} {Γ} {B B' : C⟨Γ⟩} (e : B = B')
   {Γ'} (f : Γ' --> Γ) (b : C ⟨ Γ' ⊢ B{{f}} ⟩)
 : transportf (term C Γ') (maponpaths (fun D => D{{f}}) e) b
   = transportf (fun D => term C Γ' (D{{f}})) e b.
@@ -49,24 +49,24 @@ Defined.
 End Prelims.
 
 
-(** * Type-precat from precat with Families *)
+(** * Type-cat from cat with Families *)
 
 (**
-Every pre-CwF gives rise to a type-precategory.
+Every pre-CwF gives rise to a type-category.
 
-(TODO: moreover, this type-precat should be split; and there should be a function from split type-precats back to pre-CwFs making the two equivalent.)
+(TODO: moreover, this type-cat should be split; and there should be a function from split type-cats back to pre-CwFs making the two equivalent.)
 
-Since the components of the type-precat structure are highly successively dependent, we construct most of them individually, before putting them together in [type_precat_of_precwf].
+Since the components of the type-cat structure are highly successively dependent, we construct most of them individually, before putting them together in [type_cat_of_cwf].
 *)
 
 
-Section TypePreCat_of_PreCwF.
+Section TypeCat_of_CwF.
 
 (* TODO: move the [has_homsets] assumption to the definition of a [pre_cwf]? 
    TODO: discuss namine of [has_homsets]: wouldn’t e.g. [homs_are_sets] be clearer? *)
-Context (CC : precategory) (C : cwf_struct CC) (homs_sets : has_homsets CC).
+Context (CC : category) (C : cwf_struct CC) (homs_sets : has_homsets CC).
 
-Definition type_cat1_of_precwf : typecat_structure1 CC.
+Definition type_cat1_of_cwf : typecat_structure1 CC.
 Proof.
   unfold typecat_structure1.
   exists (type C).
@@ -74,25 +74,25 @@ Proof.
   exact (fun Γ a Γ' f => a{{f}}).
 Defined.
 
-(** We can now assemble the components into a type-precategory: *)
+(** We can now assemble the components into a type-category: *)
 
-Definition type_cat_of_precwf : typecat_structure CC.
+Definition type_cat_of_cwf : typecat_structure CC.
 Proof.
-  exists type_cat1_of_precwf.
+  exists type_cat1_of_cwf.
   unfold typecat_structure2.
   exists (@proj_mor CC C).
-  exists (@q_precwf CC C).
-  exists (@dpr_q_precwf CC C).
+  exists (@q_cwf CC C).
+  exists (@dpr_q_cwf CC C).
   intros; apply @is_symmetric_isPullback. { apply homs_sets. }
   apply is_pullback_reindx_cwf. apply homs_sets.
 Defined.
 
 (** * Splitness of the constructed TypeCat *)
 
-(** Moreover, the type-precat of a pre-CwF is always split. *)
+(** Moreover, the type-cat of a pre-CwF is always split. *)
 
-Definition issplit_type_precat_of_precwf
-  : is_split_typecat type_cat_of_precwf.
+Definition issplit_type_cat_of_cwf
+  : is_split_typecat type_cat_of_cwf.
 Proof.
   unfold is_split_typecat.
   repeat split. 
@@ -101,7 +101,7 @@ Proof.
   - (* Reindexing along identities *)
     exists (reindx_type_id C).
     intros Γ A. 
-    unfold q_typecat; simpl. unfold q_precwf.
+    unfold q_typecat; simpl. unfold q_cwf.
     eapply pathscomp0. 2: { apply id_left. }
     eapply pathscomp0.
     2: refine (maponpaths (fun q => q ;; _) _).    
@@ -130,7 +130,7 @@ Proof.
     unfold ext_typecat. simpl.
     rewrite <- cwf_law_4.
     rewrite pairing_transport.
-    unfold q_precwf. 
+    unfold q_cwf. 
     rewrite cwf_law_3.
     match goal with [|- pairing ?b _ = pairing ?e _ ] => 
               set (X := b); set (X' := e)  end.
@@ -194,4 +194,4 @@ Proof.
 Qed.
 
 
-End TypePreCat_of_PreCwF.
+End TypeCat_of_CwF.

--- a/TypeTheory/OtherDefs/CwF_Pitts_to_TypeCat_to_DM.v
+++ b/TypeTheory/OtherDefs/CwF_Pitts_to_TypeCat_to_DM.v
@@ -24,9 +24,9 @@ Require Import TypeTheory.OtherDefs.TypeCat_to_DM.
 
 Section compare_maps.
 
-  Context (CC : precategory) (C : cwf_struct CC) (H : is_univalent CC).
+  Context (CC : category) (C : cwf_struct CC) (H : is_univalent CC).
 
-  Lemma maps_equal : DM_structure_of_TypeCat _ H (type_cat_of_precwf _ C (pr2 H)) = DM_structure_of_CwF _ C H.
+  Lemma maps_equal : DM_structure_of_TypeCat _ H (type_cat_of_cwf _ C (homset_property _)) = DM_structure_of_CwF _ C H.
   Proof.
     apply DM_equal.
     - exact H.

--- a/TypeTheory/OtherDefs/DM_to_TypeCat_to_DM.v
+++ b/TypeTheory/OtherDefs/DM_to_TypeCat_to_DM.v
@@ -22,11 +22,11 @@ Require Import TypeTheory.OtherDefs.TypeCat_to_DM.
 
 Section TypeCat_to_DM.
 
-Variable CC : precategory.
+Variable CC : category.
 Variable H : is_univalent CC.  
 Variable C : DM_structure CC.
 
-Lemma DM_to_TypeCat_to_DM : DM_structure_of_TypeCat _ H (type_cat_struct_from_DM _ (pr2 H)  C) = C.
+Lemma DM_to_TypeCat_to_DM : DM_structure_of_TypeCat _ H (type_cat_struct_from_DM _ (homset_property _) C) = C.
 Proof.
   apply DM_equal.
   - assumption.

--- a/TypeTheory/OtherDefs/TypeCat_to_CwF_Pitts.v
+++ b/TypeTheory/OtherDefs/TypeCat_to_CwF_Pitts.v
@@ -5,7 +5,7 @@
 
  Contents:
 
-  - Construction of a precategory with Families from Comprehension precat
+  - Construction of a category with Families from a split type-category
 
 *)
 
@@ -29,17 +29,16 @@ Defined.
   
 
 
-(** * wF structure from (split) comprehension structure on a precategory 
+(** * CwF structure from split type-category structure on a category 
 
-Every pre-(split)-Comp-cat gives rise to a pre-category with families.
+Every split-Comp-cat gives rise to a category with families.
 
-Since the components of the pre-cat with Families structure are highly successively dependent, we construct most of them individually, before putting them together in [cwf_of_type_precat].
+Since the components of the CwF structure are highly successively dependent, we construct most of them individually, before putting them together in [cwf_of_type_cat].
  *)
 
 Section CwF_of_Comp. 
 
-(* TODO: here and in other old files, use [category] instead of explicit [has_homsets] assumptions. *)
-Context (CC : precategory) (C : split_typecat_structure CC) (homs_sets : has_homsets CC).
+Context (CC : category) (C : split_typecat_structure CC).
 
 Definition tt_structure_of_typecat : tt_structure CC.
 Proof.
@@ -82,7 +81,8 @@ Proof.
 Defined.
 
 Local Definition HC : split_typecat :=
-  (((CC,,homs_sets),,pr1 C),,pr2 C).
+  ((CC,,pr1 C),,pr2 C).
+(* TODO: find or add constructor [make_split_typecat] *)
 
 Lemma reindx_laws_type_of_typecat : reindx_laws_type tt_reindx_from_typecat.
 Proof.
@@ -103,8 +103,8 @@ Lemma reindx_law_1_term_of_typecat
               (! (@reind_id_type_typecat HC Γ A)) a.
 Proof.
   intros. simpl. unfold tt_reindx_from_typecat in *. simpl in *.
-  apply subtypePath.
-  intro; apply homs_sets. simpl.
+  apply subtypePath. { intro; apply homset_property. }
+  simpl.
   apply pathsinv0.
   apply PullbackArrowUnique.
   + destruct a as [f H]; simpl in *.
@@ -122,7 +122,7 @@ Proof.
     etrans.
     apply maponpaths_2. apply T5.
     clear T5.
-    apply (transportf_dpr_typecat (((CC,,homs_sets),,(pr1 C)),,pr2 C)).
+    apply (transportf_dpr_typecat ((CC,,(pr1 C)),,pr2 C)).
 
   + simpl.
     rewrite id_left.
@@ -174,7 +174,7 @@ Proof.
   intros.
   unfold tt_reindx_from_typecat in *. simpl.
   apply subtypePath.
-  intro; apply homs_sets. simpl.
+  intro; apply homset_property. simpl.
   apply pathsinv0.
   apply PullbackArrowUnique.
   + match goal with |[|- pr1 (transportf ?P' ?e' ?x') ;; _ = _ ] =>
@@ -187,7 +187,7 @@ Proof.
     assert (T5:= base_paths _ _ T3); clear T3; simpl in *.
     etrans. apply maponpaths_2. apply T5.
     clear T5.
-    etrans. apply (transportf_dpr_typecat (((CC,,homs_sets),,pr1 C),,pr2 C)).
+    etrans. apply (transportf_dpr_typecat ((CC,,pr1 C),,pr2 C)).
     apply (@Pb_map_commutes_1).
 
   + destruct a as [f H]; simpl in *.
@@ -325,7 +325,7 @@ Proof.
 
       etrans. refine (functtransportf
                       (@rtype _ tt_reindx_type_struct_of_typecat _ _ A) _ _ _).
-      etrans. apply (transportf_reind_typecat (((CC,,homs_sets),,pr1 C),,pr2 C)).
+      etrans. apply (transportf_reind_typecat ((CC,,pr1 C),,pr2 C)).
       etrans. apply maponpaths, transportf_reind_typecat.
       etrans. apply transport_f_f.
       match goal with |[ |- transportf _ ?e' _ = _] => set (e:=e') end.
@@ -356,7 +356,7 @@ Proof.
       unshelve refine (pre_comp_with_iso_is_inj _ _ _ _ _ _ _ _).
       Focus 4.
         etrans. Focus 2. symmetry; apply assoc.
-        etrans. Focus 2. apply (@q_q_typecat (((CC,,homs_sets),,pr1 C),,pr2 C)).
+        etrans. Focus 2. apply (@q_q_typecat ((CC,,pr1 C),,pr2 C)).
       Unfocus.
       apply pr2.
     
@@ -380,7 +380,7 @@ Proof.
     etrans. apply maponpaths. apply Pb_map_commutes_2.
     etrans. symmetry. apply assoc. apply maponpaths.
     apply id_right.
-    + apply homs_sets. 
+    + apply homset_property. 
 Qed.
 
 Lemma comp_law_3_of_typecat : @comp_law_3 CC tt_reindx_type_struct_of_typecat reindx_laws_of_typecat.
@@ -405,7 +405,7 @@ Proof.
   apply maponpaths_2.
   apply functtransportf.
   rewrite <- idtoiso_postcompose.
-  rewrite (@q_q_typecat (((CC,,homs_sets),,pr1 C),,pr2 C)).
+  rewrite (@q_q_typecat ((CC,,pr1 C),,pr2 C)).
   match goal with |[ |- _ ;; ?B' ;; ?C'  = _ ]  => set (B:=B'); set (D:=C') end.
   simpl in *.
   match goal with |[ |- map_into_Pb ?B' ?C' ?D' ?E' ?F' ?G' ?Y' ?Z' ?W'  ;; _ ;; _  = _ ] => 
@@ -451,15 +451,14 @@ Proof.
     + apply comp_laws_1_2_of_typecat. 
     + apply comp_law_3_of_typecat. 
     + apply comp_law_4_of_typecat.
-  -  assumption.
   - apply (@isaset_types_typecat HC).
   - simpl.
     intros.
     apply (isofhleveltotal2 2).
-    + apply homs_sets.
+    + apply homset_property.
     + intros.
       apply hlevelntosn.
-      apply homs_sets.
+      apply homset_property.
 Qed.
 
 Definition cwf_of_typecat : cwf_struct CC.

--- a/TypeTheory/OtherDefs/TypeCat_to_DM.v
+++ b/TypeTheory/OtherDefs/TypeCat_to_DM.v
@@ -19,7 +19,7 @@ Require Import TypeTheory.OtherDefs.DM.
 
 Section TypeCat_to_DM.
 
-Variable CC : precategory.
+Variable CC : category.
 Variable H : is_univalent CC.  
 Variable C : typecat_structure CC.
 
@@ -77,19 +77,18 @@ Proof.
   destruct T as [A [h e]].
   clear B.
   unshelve refine (tpair _ _ _ ).
-  - unshelve refine (make_Pullback _ _ _ _ _ _ _ ).
+  - unshelve refine (make_Pullback _ _).
     + apply (Γ' ◂ (A{{f}})).
     + apply (q_typecat _ _ ;; h).
     + apply (dpr_typecat _ ).
     + simpl. unfold dm_sub_struct_of_TypeCat.
       simpl.
-      set (T:= postcomp_pb_with_iso CC (pr2 H)).
-      refine (pr1 (T _ _ _ _  (q_typecat A f) _ _ f _ _ _ _ _ _ )).
-      apply is_symmetric_isPullback. exact (pr2 H).
+      set (T:= postcomp_pb_with_iso CC (homset_property _)).
+      refine (pr1 (T _ _ _ _ (q_typecat A f) _ _ f _ _ _ _ _ _)).
+      apply is_symmetric_isPullback. { apply homset_property. }
       apply reind_pb_typecat.
       sym. assumption.
-    + 
-      set (T:= postcomp_pb_with_iso CC (pr2 H)).
+    + set (T:= postcomp_pb_with_iso CC (homset_property _)).
       eapply (pr2 (T _ _ _ _ _ _ _ _ _ _ _ _ _ _)).
  - simpl.
     apply hinhpr.

--- a/TypeTheory/TypeConstructions/CwF_SplitTypeCat_TypeEquiv.v
+++ b/TypeTheory/TypeConstructions/CwF_SplitTypeCat_TypeEquiv.v
@@ -269,7 +269,7 @@ Proof.
   induction eqH.
   assert (eqK : K = K') by exact (pr1(pr2 C _ _ _ _ _ _)).
   induction eqK.
-  assert (eqPb: isPb = isPb') by exact (pr1(isaprop_isPullback _ _ _ _ _ _ _)).
+  assert (eqPb: isPb = isPb') by exact (pr1 (isaprop_isPullback _ _ _ _ _ _ _ _)).
   induction eqPb.
   reflexivity.
 Qed.

--- a/TypeTheory/TypeConstructions/CwF_Structure_Display.v
+++ b/TypeTheory/TypeConstructions/CwF_Structure_Display.v
@@ -81,7 +81,7 @@ Local Definition te {Γ : C} (A : Ty Γ : hSet) : tm (#Ty (pi A) A)
 := pr12 pr22 CwF _ A.
 (* proof of pp (te A) = Ty (pi A) A*)
 Local Definition te' {Γ : C} (A : Ty Γ : hSet) : pp_ _ (te A) = #Ty (pi A) A := pr212 pr22 CwF Γ A.
-Definition CwF_Pullback {Γ} (A : Ty Γ : hSet) : isPullback (yy A) pp (#Yo (pi A)) (yy(te A)) (cwf_square_comm (te' A)) := pr22 pr22 CwF Γ A.
+Definition CwF_Pullback {Γ} (A : Ty Γ : hSet) : isPullback (cwf_square_comm (te' A)) := pr22 pr22 CwF Γ A.
 
 Local Definition tm_transportf {Γ} {A A' : Ty Γ : hSet} (e : A = A')
 : tm A ≃ tm A'.
@@ -208,17 +208,17 @@ Lemma yonedacarac {Γ Δ : C} (f  : _ ⟦Yo Γ,Yo Δ⟧)
 Proof.
   assert (H : (# Yo ((f : nat_trans _ _) Γ (identity Γ)) : nat_trans _ _) Γ (identity Γ)
                = (f : nat_trans _ _) Γ (identity Γ)) by apply (id_left _).
-  assert (Map1 : (f : nat_trans _ _) Γ (identity Γ) = yoneda_map_1 C (pr2 C) Γ (Yo(Δ)) f) by reflexivity.
-  assert (Map2 : # Yo ((f : nat_trans _ _) Γ (identity Γ)) = yoneda_map_2 C (pr2 C) Γ (Yo(Δ))
+  assert (Map1 : (f : nat_trans _ _) Γ (identity Γ) = yoneda_map_1 C Γ (Yo(Δ)) f) by reflexivity.
+  assert (Map2 : # Yo ((f : nat_trans _ _) Γ (identity Γ)) = yoneda_map_2 C Γ (Yo(Δ))
          ((f : nat_trans _ _) Γ (identity Γ))).                                      
   -  unfold yoneda_map_2; cbn; unfold yoneda_morphisms; unfold yoneda_morphisms_data; cbn.
-     assert (nattrans : is_nat_trans_yoneda_morphisms_data C _ Γ Δ
+     assert (nattrans : is_nat_trans_yoneda_morphisms_data C Γ Δ
          ((f :nat_trans _ _) Γ (identity Γ))
-          = yoneda_map_2_ax C (pr2 C) Γ (yoneda_objects C _ Δ)
+          = yoneda_map_2_ax C Γ (yoneda_objects C Δ)
           ((f : nat_trans _ _) Γ (identity Γ))).
-     --  assert (prop : isaprop(is_nat_trans (yoneda_objects C _ Γ)
-         (yoneda_objects C (homset_property C) Δ)
-         (yoneda_morphisms_data C _ Γ Δ
+     --  assert (prop : isaprop(is_nat_trans (yoneda_objects C Γ)
+         (yoneda_objects C Δ)
+         (yoneda_morphisms_data C Γ Δ
          ((f : nat_trans _ _) Γ (identity Γ))))) by (apply isaprop_is_nat_trans;exact (pr2 hset_category));
         exact (pr1 (prop _ _)).
      --  apply pair_path_in2; apply nattrans.
@@ -231,7 +231,7 @@ Proof.
 Qed.
 
 Lemma yyidentity {Γ : C} {A : Ty Γ : hSet} (B : Ty (Γ.:A) : hSet) 
-: B = (@yy (pr1 C) (pr2 C) Ty (Γ.:A) B : nat_trans _ _) (Γ.:A) (identity (Γ.:A)).
+: B = (@yy C Ty (Γ.:A) B : nat_trans _ _) (Γ.:A) (identity (Γ.:A)).
 Proof.
   apply pathsinv0; eapply pathscomp0.
   -  apply (toforallpaths _ (# Ty _) _ (functor_id Ty (Γ.:A))).
@@ -244,9 +244,9 @@ Section qq.
 (** morphism between contexts *)
 
 Let Xk {Γ : C} (A : Ty Γ : hSet) :=
-  make_Pullback _ _ _ _ _ _ (pr22 pr22 CwF Γ A).
+  make_Pullback _ (pr22 pr22 CwF Γ A).
 
-Local Definition qq_yoneda {Γ  Δ : C} (A : Ty Γ : hSet) (f : C^op ⟦Γ,Δ⟧)
+Local Definition qq_yoneda {Γ  Δ : C} (A : Ty Γ : hSet) (f : C ⟦Δ,Γ⟧)
 : (preShv C) ⟦Yo (Δ .: (#Ty f A)), Yo (Γ.: A) ⟧.
 Proof.
   use (PullbackArrow (Xk A)).
@@ -278,7 +278,7 @@ Qed.
 Local Definition qq_term {Γ  Δ : C} (A : Ty Γ : hSet) (f : C^op ⟦Γ,Δ⟧)
 : C ⟦ Δ.:(#Ty f A) , Γ.: A⟧.
 Proof.
-  apply (invweq (make_weq _ (yoneda_fully_faithful _ (homset_property _) _ _ ))) ,
+  apply (invweq (make_weq _ (yoneda_fully_faithful _ _ _ ))) ,
   (qq_yoneda A f).
 Defined.
 
@@ -286,7 +286,7 @@ Lemma qq_yoneda_compatibility {Γ  Δ : C} (A : Ty Γ : hSet) (f : C^op ⟦Γ,Δ
  #Yo(qq_term A f) = qq_yoneda A f.
 Proof.
   apply (homotweqinvweq
-  (make_weq _ (yoneda_fully_faithful _ (homset_property _) ( _ .:(#Ty f A)) (Γ.:A)))).
+  (make_weq _ (yoneda_fully_faithful _ ( _ .:(#Ty f A)) (Γ.:A)))).
 Qed.
 
 Lemma qq_term_te {Γ Δ : C} (A : Ty Γ : hSet) (f : C^op ⟦Γ,Δ⟧) 
@@ -295,18 +295,19 @@ Proof.
   assert (Hyp := qq_yoneda_commutes A f).
   rewrite <- qq_yoneda_compatibility in Hyp. 
   apply (pathscomp0 (yy_natural  _ _ _ _ _)) in Hyp.
-  apply (invmaponpathsweq (@yy _ (pr2 C) _ _) ).
+  apply (invmaponpathsweq (@yy _ _ _) ).
   exact Hyp.
 Qed.
 
 Lemma qq_term_pullback {Γ  Δ :C} (A : Ty Γ : hSet) (f : C^op ⟦Γ,Δ⟧)
 : f ;; pi (#Ty f A) = (qq_term A f);; pi A.
 Proof.
+  cbn; cbn in f.
   assert (XT := (qq_yoneda_commutes_1 A f)).
   rewrite <- qq_yoneda_compatibility in XT.
   do 2 rewrite <- functor_comp in XT.
-  apply (invmaponpathsweq (make_weq _ (yoneda_fully_faithful _ (homset_property _) _ _ ))).
-  cbn; cbn in XT; exact XT.
+  apply (invmaponpathsweq (make_weq _ (yoneda_fully_faithful _ _ _ ))).
+  exact XT.
 Qed.
 
 Section Familly_Of_Types.
@@ -340,8 +341,8 @@ Lemma γNat {Γ Δ : C} {A : Ty Γ : hSet} (f : C^op ⟦Γ,Δ⟧) (a : tm A)
 Proof.
   assert (Yoγ : #Yo ((f : C⟦Δ,Γ⟧) ;; (γ a : nat_trans _ _) Γ (identity Γ)) =
   #Yo((γ (reind_tm f a) : nat_trans _ _) Δ (identity Δ) ;; qq_term A f)).
-  -  do 2 (rewrite (pr22 (yoneda C (pr2 C)) _ _ _); rewrite yonedacarac).
-     refine (MorphismsIntoPullbackEqual (CwF_Pullback A)
+  -  do 2 (rewrite (pr22 (yoneda C) _ _ _); rewrite yonedacarac).
+     cbn in f. refine (MorphismsIntoPullbackEqual (CwF_Pullback A) _
      (#Yo f ;; γ a) (γ (reind_tm f a) ;; #Yo (qq_term A f)) _ _).
      --  rewrite <- assoc.
          eapply pathscomp0.
@@ -360,7 +361,7 @@ Proof.
                 rewrite  (cancel_postcomposition _ _ _
                 (pr121 ((CwF_Pullback _) (Yo Δ) (identity (Yo Δ))
                 (yy(#Tm f a)) (Subproof_γ (reind_tm f a) )))).
-                apply (pr1 (pr121 (preShv C)) _ (Yo Γ) (#Yo f)).
+                apply id_left.
             **  reflexivity.
     --  rewrite <- assoc.
         apply (pathscomp0  (cancel_precomposition _ _ _ _ _ _ _
@@ -397,14 +398,8 @@ Lemma  γPullback2 {Γ : C} (A : Ty Γ : hSet)
 : γ (te A) ;; #Yo (qq_term A (pi A)) ;; #Yo (pi A) = identity _;;(#Yo (pi A)).
 Proof.
   assert (Eq1 : #Yo (pi (#Ty (pi A) A)) ;; #Yo (pi A) = qq_yoneda A (pi A) ;; #Yo (pi A)) by (
-  rewrite <- (pr121((pr22(make_Pullback (yy A) pp
-    (yoneda (pr1 CwF) (homset_property (pr1 CwF))
-    (Γ.:A))
-    (# (yoneda (pr1 CwF) (homset_property (pr1 CwF)))
-    (pi A))
-    (yy (pr112 (pr22 CwF Γ A)))
-    (cwf_square_comm (pr212 (pr22 CwF Γ A)))
-    (CwF_Pullback A))) (Yo (_ .: (#Ty (pi A) A)))
+  rewrite <- (pr121((pr22(make_Pullback _ (CwF_Pullback A)))
+    (Yo (_ .: (#Ty (pi A) A)))
     (#Yo (pi (#Ty (pi A) A)) ;; #Yo (pi A)) (yy (te (#Ty (pi A) A)))
     (qq_yoneda_subproof Γ (Γ.: A) A (pi A))));          
   auto).         
@@ -425,17 +420,17 @@ Proof.
   exact (Yo^-1 (γ a) ;; qq_term A f).    
 Defined.
 
-Lemma γ_pi {Γ} {A : Ty Γ: hSet} (a : tm A) : Yo^-1 (γ a) ;; pi A = identity _.
+Lemma γ_pi {Γ:C} {A : Ty Γ: hSet} (a : tm A) : Yo^-1 (γ a) ;; pi A = identity _.
 Proof.
-  assert (Yoeq : #Yo(Yo^-1 (γ a) ;; pi A) = #Yo(identity Γ)).
+  assert (Yoeq : #Yo(Yo^-1 (γ a) ;; pi A) = #Yo (identity Γ)).
   -  apply (pathscomp0 (pr22 Yo _ _ _  _ _ )).
      apply pathsinv0 , (pathscomp0 (pr12 Yo _)).    
-     assert (simplman : identity (pr1 (yoneda C (homset_property C)) Γ) 
+     assert (simplman : identity (pr1 (yoneda C) Γ) 
      = identity (Yo Γ)) by auto.
      apply (pathscomp0 simplman).
      rewrite (!(pull_γ a)).
      apply cancel_postcomposition.
-     assert (simplman2 : # (pr1 (yoneda C (homset_property C))) (Yo^-1 (γ a))
+     assert (simplman2 : # (pr1 (yoneda C)) (Yo^-1 (γ a))
      = #Yo (Yo^-1 (γ a))) by auto.
      apply pathsinv0, (pathscomp0 simplman2), invyoneda.
   -  apply (maponpaths (Yo^-1) ) in Yoeq.
@@ -445,7 +440,7 @@ Qed.
 
 Lemma te_subtitution {Γ} {A : Ty Γ : hSet} (a : tm A) : #Tm (Yo^-1(γ a)) (te A) = a.
 Proof.
-  assert (inter : @yy _ (pr2 C) _ _ (#Tm (Yo^-1(γ a)) (te A)) = yy a). 
+  assert (inter : @yy _ _ _ (#Tm (Yo^-1(γ a)) (te A)) = yy a). 
   -  rewrite yy_natural, invyoneda. 
      exact (pr221((CwF_Pullback _) (Yo _) (identity _) (yy _) (Subproof_γ _))).
   -  apply (maponpaths (invmap yy) ) in inter.
@@ -509,7 +504,7 @@ Lemma DepTypesEta {Γ : C} {A : Ty Γ : hSet} (B : Ty (Γ.:A) : hSet)
 Proof.
   assert (Natu : @γ (Γ.:A) (#Ty (pi A) A) (te A) ;; yy (# Ty (qq_term A (pi A)) B)
   = @γ (Γ.:A) (#Ty (pi A) A) (te A) ;; #Yo (qq_term A (pi A)) ;; 
-  (@yy (@pr1 _ _ C) (@pr2 _ _ C) Ty (Γ .: A)) B).
+  (@yy _ Ty (Γ .: A)) B).
   -  rewrite (cancel_precomposition _ _ _ _ (yy (#Ty (qq_term A (pi A)) B))
      (#Yo (qq_term A (pi A));; yy B) _).
      *  rewrite assoc; reflexivity.
@@ -517,12 +512,7 @@ Proof.
   -  assert (Id: @γ (Γ .: A) (# Ty (@pi Γ A) A) (te A) ;; #Yo (qq_term A (pi A))
      = identity _).
      *  refine (MorphismsIntoPullbackEqual
-        (pr22(make_Pullback (yy A) pp
-        (yoneda (pr1 CwF) (homset_property (pr1 CwF)) (Γ.:A))
-        (# (yoneda (pr1 CwF) (homset_property (pr1 CwF))) (pi A))
-        (yy (te A))
-        (cwf_square_comm (te' A))
-        (CwF_Pullback A)))
+        (pr22(make_Pullback _ (CwF_Pullback A))) _
         (γ (te A) ;; #Yo (qq_term A (pi A))) (identity _) (γPullback2 A) (γPullback1 A)).
      *  rewrite Id, (id_left _) in Natu.
         unfold DepTypesType.

--- a/TypeTheory/TypeConstructions/SplTCwF_TypeFormers.v
+++ b/TypeTheory/TypeConstructions/SplTCwF_TypeFormers.v
@@ -7,6 +7,7 @@ Require Import TypeTheory.ALV1.CwF_SplitTypeCat_Defs.
 Require Import TypeTheory.ALV1.CwF_SplitTypeCat_Maps.
 Require Import TypeTheory.ALV1.CwF_SplitTypeCat_Equivalence.
 
+(* TODO: in general, try to replace use of iterated projections by access functions (more robust + readable)! *)
 Notation "'pr1121' x" := (pr1(pr1(pr2(pr1(x))))) (at level 30).
 Notation "'pr2121' x" := (pr2(pr1(pr2(pr1(x))))) (at level 30).
 Notation "'pr1111' x" := (pr1(pr1(pr1(pr1(x))))) (at level 30).
@@ -88,12 +89,12 @@ Definition var {Γ} (A : Ty Γ : hSet) : tm (A⌊pi A⌋) := (var' A,, var_commu
 Definition Yo_var_commut {Γ} (A : Ty Γ : hSet) : #Yo (pi A) ;; yy A = yy(var A) ;; p
 := term_fun_str_square_comm (var A).
 Definition term_pullback {Γ} (A : Ty Γ : hSet)
-: isPullback _ _ _ _ (Yo_var_commut A)
+: isPullback (Yo_var_commut A)
 := isPullback_Q_pp C A.
 
 Definition q {Γ Δ} (A : Ty Γ : hSet) (f : C^op⟦Γ,Δ⟧) : C⟦Δ¤(A⌊f⌋),Γ¤A⟧ := qq C f A.
 Definition q_eq {Γ Δ} (A : Ty Γ : hSet) (f : C^op⟦Γ,Δ⟧) : pi _ ;; f = q A f ;; pi _ := !(qq_π C f A).
-Definition q_pullback {Γ Δ} (A : Ty Γ : hSet) (f : C^op⟦Γ,Δ⟧) : isPullback _ _ _ _ (q_eq A f) := qq_π_Pb C f A.
+Definition q_pullback {Γ Δ} (A : Ty Γ : hSet) (f : C^op⟦Γ,Δ⟧) : isPullback (q_eq A f) := qq_π_Pb C f A.
 Definition compatibility_splTCwF {Γ Δ : C} (A : Ty Γ : hSet) (f : C⟦Δ, Γ⟧) : # Tm (q A f) (var A) = var (A⌊f⌋) := !(pr222 C Γ Δ A f).
 
 End access.
@@ -122,18 +123,18 @@ Lemma yonedacarac {Γ Δ : C} (f  : _ ⟦Yo Γ,Yo Δ⟧)
 Proof.
   assert (H : (# Yo ((f : nat_trans _ _) Γ (identity Γ)) : nat_trans _ _) Γ (identity Γ)
                = (f : nat_trans _ _) Γ (identity Γ)) by apply (id_left _).
-  assert (Map1 : (f : nat_trans _ _) Γ (identity Γ) = yoneda_map_1 C (pr21 C) Γ (Yo(Δ)) f)
+  assert (Map1 : (f : nat_trans _ _) Γ (identity Γ) = yoneda_map_1 C Γ (Yo(Δ)) f)
   by reflexivity.
-  assert (Map2 : # Yo ((f : nat_trans _ _) Γ (identity Γ)) = yoneda_map_2 C (pr21 C) Γ (Yo(Δ))
+  assert (Map2 : # Yo ((f : nat_trans _ _) Γ (identity Γ)) = yoneda_map_2 C Γ (Yo(Δ))
          ((f : nat_trans _ _) Γ (identity Γ))).                                      
   -  unfold yoneda_map_2; cbn; unfold yoneda_morphisms; unfold yoneda_morphisms_data; cbn.
-     assert (nattrans : is_nat_trans_yoneda_morphisms_data C _ Γ Δ
+     assert (nattrans : is_nat_trans_yoneda_morphisms_data C Γ Δ
          ((f :nat_trans _ _) Γ (identity Γ))
-          = yoneda_map_2_ax C (pr21 C) Γ (yoneda_objects C _ Δ)
+          = yoneda_map_2_ax C Γ (yoneda_objects C Δ)
           ((f : nat_trans _ _) Γ (identity Γ))).
-     --  assert (prop : isaprop(is_nat_trans (yoneda_objects C _ Γ)
-         (yoneda_objects C (homset_property C) Δ)
-         (yoneda_morphisms_data C _ Γ Δ
+     --  assert (prop : isaprop(is_nat_trans (yoneda_objects C Γ)
+         (yoneda_objects C Δ)
+         (yoneda_morphisms_data C Γ Δ
          ((f : nat_trans _ _) Γ (identity Γ))))) by (apply isaprop_is_nat_trans;exact (pr2 hset_category));
         exact (pr1 (prop _ _)).
      --  apply pair_path_in2; apply nattrans.
@@ -152,7 +153,7 @@ rewrite (!(yonedacarac _)). rewrite yonedainv ,yonedacarac. reflexivity.
 Qed.
 
 Lemma yyidentity {Γ : C} {A : Ty Γ : hSet} (B : Ty (Γ¤A) : hSet) 
-: B = (@yy (pr1 C) (pr21 C) Ty (Γ¤A) B : nat_trans _ _) (Γ¤A) (identity (Γ¤A)).
+: B = (@yy (pr1 C) Ty (Γ¤A) B : nat_trans _ _) (Γ¤A) (identity (Γ¤A)).
 Proof.
   apply pathsinv0; eapply pathscomp0.
   -  apply (toforallpaths _ (# Ty _) _ (functor_id Ty (Γ¤A))).
@@ -160,7 +161,7 @@ Proof.
 Qed.
 
 
-Lemma q_eq_yoneda {Γ Δ} (A : Ty Γ : hSet) (f : C^op⟦Γ,Δ⟧) : #Yo(pi _) ;; #Yo f = #Yo (q A f) ;; #Yo (pi _).
+Lemma q_eq_yoneda {Γ Δ} (A : Ty Γ : hSet) (f : C⟦Δ,Γ⟧) : #Yo(pi _) ;; #Yo f = #Yo (q A f) ;; #Yo (pi _).
 Proof.
     rewrite (!(pr22 Yo _ _ _ (q A f) _)),(!(pr22 Yo _ _ _ _ f)).
     rewrite q_eq.
@@ -227,32 +228,32 @@ Proof.
         (Subproof_γ a))))); auto.
 Qed.
 
-Lemma γ_pi {Γ} {A : Ty Γ: hSet} (a : tm A) : Yo^-1 (γ a) ;; pi A = identity _.
+Lemma γ_pi {Γ : C} {A : Ty Γ: hSet} (a : tm A) : Yo^-1 (γ a) ;; pi A = identity _.
 Proof.
   assert (Yoeq : #Yo(Yo^-1 (γ a) ;; pi A) = #Yo(identity Γ)).
   -  apply (pathscomp0 (pr22 Yo _ _ _  _ _ )).
      apply pathsinv0 , (pathscomp0 (pr12 Yo _)).    
-     assert (simplman : identity (pr1 (yoneda C (homset_property C)) Γ) 
+     assert (simplman : identity (pr1 (yoneda C) Γ) 
      = identity (Yo Γ)) by auto.
      apply (pathscomp0 simplman).
      rewrite (!(pull_γ a)).
      apply cancel_postcomposition.
-     assert (simplman2 : # (pr1 (yoneda C (homset_property C))) (Yo^-1 (γ a))
+     assert (simplman2 : # (pr1 (yoneda C)) (Yo^-1 (γ a))
      = #Yo (Yo^-1 (γ a))) by auto.
      apply pathsinv0, (pathscomp0 simplman2), invyoneda.
   -  apply (maponpaths (Yo^-1) ) in Yoeq.
      rewrite yonedainv, yonedainv in Yoeq.
      exact Yoeq.
 Qed.
-Lemma γNat {Γ Δ : C} {A : Ty Γ : hSet} (f : C^op ⟦Γ,Δ⟧) (a : tm A)
+Lemma γNat {Γ Δ : C} {A : Ty Γ : hSet} (f : C ⟦Δ,Γ⟧) (a : tm A)
 : (f : C⟦Δ,Γ⟧) ;; (γ a : nat_trans _ _) Γ (identity Γ) =
   (γ (a ⌈f⌉) ;; #Yo (q A f) : nat_trans _ _) Δ (identity Δ).
 Proof.
   assert (Yoγ : #Yo ((f : C⟦Δ,Γ⟧) ;; (γ a : nat_trans _ _) Γ (identity Γ)) =
   #Yo((γ (a ⌈f⌉) : nat_trans _ _) Δ (identity Δ) ;; q A f)).
-  -  do 2 (rewrite (pr22 (yoneda C (pr21 C)) _ _ _); rewrite yonedacarac).
-     refine (MorphismsIntoPullbackEqual (term_pullback A)
-     (#Yo f ;; γ a) (γ (a ⌈f⌉) ;; #Yo (q A f)) _ _).
+  -  do 2 (rewrite (pr22 (yoneda C) _ _ _); rewrite yonedacarac).
+     refine (MorphismsIntoPullbackEqual (term_pullback A) _
+                       (#Yo f ;; γ a) (γ (a ⌈f⌉) ;; #Yo (q A f)) _ _).
      --  rewrite <- assoc.
          eapply pathscomp0.
          *  rewrite (cancel_precomposition _ _ _ _ _ _ _
@@ -268,7 +269,7 @@ Proof.
                 rewrite  (cancel_postcomposition _ _ _
                 (pr121 ((term_pullback _) (Yo Δ) (identity (Yo Δ))
                 (yy(#Tm f a)) (Subproof_γ (a ⌈f⌉) )))).
-                apply (pr1 (pr121 (preShv C)) _ (Yo Γ) (#Yo f)).
+                apply id_left.
             **  reflexivity.
     --  rewrite <- assoc.
         apply (pathscomp0  (cancel_precomposition _ _ _ _ _ _ _
@@ -327,7 +328,7 @@ Proof.
   intros [a  pa]; use tpair.
   -  exact (invmap (yy) (#Yo a;; yy(var A))).
   -  abstract (set (a' := invmap (yy) (#Yo a;; yy(var A))); simpl;
-     assert (eqA : @yy _ (pr21 C) _ _ A = yy a' ;; p);
+     assert (eqA : @yy _ _ _ A = yy a' ;; p);
      [ apply (maponpaths (#Yo )) in pa;
         unfold a';
         rewrite homotweqinvweq;
@@ -359,7 +360,7 @@ Proof.
           exact (!(pr12 Yo _))
           | apply (pathscomp0 simplman4);
              exact lem]]
-  | assert (eqa' : @yy _ (pr21 C) _ _ (p _ a') = yy a';;p)
+  | assert (eqa' : @yy _ _ _ (p _ a') = yy a';;p)
      by (rewrite yy_comp_nat_trans; reflexivity);
      rewrite <- eqa' in eqA;
      apply (maponpaths (invmap yy)) in eqA;
@@ -372,7 +373,7 @@ Proof.
 intro a;
 apply subtypePath.
 - intro x; exact (setproperty (Ty Γ : hSet) _ _).
-- assert (eqa : invmap yy (# (yoneda C (homset_property C)) (Yo^-1 (γ a)) ;; yy (var A)) = a)
+- assert (eqa : invmap yy (# (yoneda C) (Yo^-1 (γ a)) ;; yy (var A)) = a)
    by (rewrite invyoneda,γ_pull, homotinvweqweq; reflexivity);  exact eqa.
 Qed.
 
@@ -381,18 +382,13 @@ Proof.
 intro a;
 apply subtypePath.
 - intro x; apply (pr21 C).
-- assert (eqa : (Yo^-1 (γ (invmap yy (# (yoneda C (homset_property C)) (pr1 a) ;; yy (var A)),,
+- assert (eqa : (Yo^-1 (γ (invmap yy (# (yoneda C) (pr1 a) ;; yy (var A)),,
     tm_map_2_subproof Γ A (pr1 a) (pr2 a)))) = a).
   rewrite <- (yonedainv a) ; apply maponpaths.
-  refine (MorphismsIntoPullbackEqual _ _ _ _ _).
-  -- exact (pr22(make_Pullback (yy A) p (yoneda C (homset_property C) (Γ¤A))
-        (# (yoneda C (homset_property C)) (pi A)) (yy (var A))
-        (Yo_var_commut _) (term_pullback A))).
-  --  assert (eqpiA : pr121 (make_Pullback (yy A) p
-      (yoneda C (homset_property C) (Γ¤A))
-      (# (yoneda C (homset_property C)) 
-      (pi A)) (yy (var A)) (Yo_var_commut _)
-      (term_pullback A)) = #Yo(pi A)) by auto. 
+  refine (MorphismsIntoPullbackEqual _ _ _ _ _ _).
+  -- exact (pr22 (make_Pullback _ (term_pullback A))).
+  --  assert (eqpiA : pr121 (make_Pullback _ (term_pullback A)) = #Yo(pi A)) 
+        by auto. 
       rewrite eqpiA.
       apply (pathscomp0 (pull_γ _)).
       assert (simplman2 : # Yo a = # (pr1 Yo) a ) by auto;
@@ -405,11 +401,8 @@ apply subtypePath.
       apply pathsinv0.
       apply (pathscomp0  (!(pr22 Yo _ _ _ a (pi A)))).
       apply maponpaths. exact (pr2 a).
-  --  assert (eqteA : pr221 (make_Pullback (yy A) p
-      (yoneda C (homset_property C)
-      (Γ¤A)) (# (yoneda C (homset_property C))
-      (pi A)) (yy (var A)) (Yo_var_commut _)
-      (term_pullback A)) = yy(var A)) by auto.
+  --  assert (eqteA : pr221 (make_Pullback _ (term_pullback A)) = yy(var A))
+        by auto.
       rewrite eqteA.
       rewrite γ_pull.
       apply homotweqinvweq.
@@ -693,7 +686,7 @@ Qed.
 
 Lemma var_subtitution {Γ} {A : Ty Γ : hSet} (a : tm A) : #Tm a (var A) = a.
 Proof.
-  assert (inter : @yy _ (pr21 C) _ _ (#Tm a (var A)) = yy a). 
+  assert (inter : @yy _ _ _ (#Tm a (var A)) = yy a). 
   -  assert (eqa : Yo^-1 (γ a) = a ) by auto. 
      rewrite (!eqa), yy_natural, invyoneda. 
      exact (pr221((term_pullback _) (Yo _) (identity _) (yy _) (Subproof_γ _))).
@@ -708,17 +701,10 @@ Lemma reind_tm_q {Γ Δ} (f : C^op ⟦Γ,Δ⟧)
 Proof.
   assert (eqYo : #Yo(a ⌈f⌉ ;; q A f) = #Yo((f : C⟦Δ,Γ⟧) ;; a)).
   -  simple refine (MorphismsIntoPullbackEqual
-     (pr22(make_Pullback (yy A) p
-     (yoneda C (pr21 C) (Γ¤A))
-     (# (yoneda C (pr21 C)) (pi A))
-     (yy (var A))
-     (Yo_var_commut _)
-     (term_pullback A)))
-     (#Yo(a ⌈f⌉ ;; q A f)) (#Yo((f : C⟦Δ,Γ⟧) ;; a)) _ _).
-     *  assert (triv : pr121 
-        (make_Pullback (yy A) p (yoneda C (pr21 C) (ext Γ A))
-        (# (yoneda C (pr21 C)) (pi A)) (yy (var A)) (Yo_var_commut A) 
-        (term_pullback A)) = #Yo(pi A)) by auto.
+       (pr22(make_Pullback _ (term_pullback A)))
+       _ (#Yo(a ⌈f⌉ ;; q A f)) (#Yo((f : C⟦Δ,Γ⟧) ;; a)) _ _).
+     *  assert (triv : pr121 (make_Pullback _ (term_pullback A)) = #Yo(pi A))
+          by auto.
         rewrite triv.
         rewrite (pr22 Yo _ _ _  _ a).
         rewrite (pr22 Yo _ _ _  _ (q A f)).
@@ -729,17 +715,15 @@ Proof.
         do 2 rewrite pull_γ.
         rewrite id_left,id_right.
         reflexivity.
-     *  assert (triv : pr221 
-        (make_Pullback (yy A) p (yoneda C (pr21 C) (ext Γ A))
-        (# (yoneda C (pr21 C)) (pi A)) (yy (var A)) (Yo_var_commut A) 
-        (term_pullback A)) = @yy _ (pr21 C) _ _ (var A)) by auto.
+     *  assert (triv : pr221 (make_Pullback _ (term_pullback A))
+                       = @yy _ _ _ (var A)) by auto.
         rewrite triv.
         rewrite (pr22 Yo _ _ _  _ a).
         rewrite (pr22 Yo _ _ _  _ (q A f)).
         do 2 rewrite <- assoc.
         assert (evidq : # (pr1 Yo) (q A f) = # Yo (q A f) ) by auto;
         rewrite evidq;
-        assert (evida : # (pr1 Yo) a = # (@yoneda _ (pr21 C)) a ) by auto;
+        assert (evida : # (pr1 Yo) a = # Yo a ) by auto;
         rewrite evida.
         eapply pathscomp0.
         exact (cancel_precomposition _ _ _ _ _ _ _ (!(yy_natural _ _ (var A) _ (q A f)))).
@@ -748,7 +732,7 @@ Proof.
         exact (cancel_precomposition _ _ _ _ _ _ _ (!(yy_natural _ _ (var A) _ a))).
         rewrite compatibility_splTCwF.
         rewrite var_subtitution.
-        assert (evidf : # (pr1 Yo) f = # Yo f) by auto;
+        simpl in f. assert (evidf : # (pr1 Yo) f = # Yo f) by auto;
         rewrite evidf;
         eapply pathscomp0.
         exact (!(yy_natural _ _ a _ f)).
@@ -801,9 +785,8 @@ Proof.
   use subtypePath.
   -  intro x; apply (setproperty (Ty Γ : hSet)).
   - cbn.
-    assert (eqγ : (yoneda_map_1 C (homset_property C) Γ
-    (yoneda_objects C (homset_property C) (ext Γ A)) 
-    (γ a)) = Yo^-1 (γ a)) by auto;
+    assert (eqγ : (yoneda_map_1 C Γ (yoneda_objects C (ext Γ A)) (γ a))
+                  = Yo^-1 (γ a)) by auto;
     rewrite eqγ;
     rewrite invyonedacarac.
     reflexivity.
@@ -834,7 +817,7 @@ Lemma DepTypesEta {Γ : C} {A : Ty Γ : hSet} (B : Ty (Γ¤A) : hSet)
 Proof.
   assert (Natu : @γ (Γ¤A) (A ⌊pi A⌋) (var A) ;; yy (B ⌊q A (pi A)⌋)
   = @γ (Γ¤A) (#Ty (pi A) A) (var A) ;; #Yo (q A (pi A)) ;; 
-  (@yy C (pr21 C) Ty (Γ¤A)) B).
+  (@yy C Ty (Γ¤A)) B).
   -  rewrite (cancel_precomposition _ _ _ _ (yy (B ⌊q A (pi A)⌋))
      (#Yo (q A (pi A));; yy B) _).
      *  rewrite assoc; reflexivity.
@@ -842,13 +825,8 @@ Proof.
   -  assert (Id: @γ (Γ¤A) (# Ty (@pi Γ A) A) (var A) ;; #Yo (q A (pi A))
      = identity _).
      *  refine (MorphismsIntoPullbackEqual
-        (pr22(make_Pullback (yy A) p
-        (yoneda C (homset_property C) (Γ¤A))
-        (# (yoneda C (homset_property C)) (pi A))
-        (yy (var A))
-        (Yo_var_commut _)
-        (term_pullback A)))
-        (γ (var A) ;; #Yo (q A (pi A))) (identity _) (γPullback2 A) (γPullback1 A)).
+        (pr22(make_Pullback _ (term_pullback A)))
+        _ (γ (var A) ;; #Yo (q A (pi A))) (identity _) (γPullback2 A) (γPullback1 A)).
      *  rewrite Id, (id_left _) in Natu.
         unfold DepTypesType.
         rewrite Natu; exact (!(yyidentity B)).


### PR DESCRIPTION
All of UniMath/TypeTheory is now fixed up to build against UniMath/UniMath@7d1550fd .

It would be good also to refactor this library along similar lines — primarily, make sure that all uses of `(C:precategory) (H : has_homsets C)` get bundled into `(C:category)`.  (In this PR, I’ve done that in a few places when it interacted with fixing the build, but I haven’t done it everywhere possible.)  But I suggest we merge this PR for now to fix the build, and open that refactoring suggestion as a separate issue.